### PR TITLE
Feature: Identify Devices/Users Across Apps

### DIFF
--- a/Example/Example.xcodeproj/project.pbxproj
+++ b/Example/Example.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		4DED8D4A20575A9C001CA7DF /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 4DED8D4820575A9C001CA7DF /* Main.storyboard */; };
 		4DED8D4C20575A9C001CA7DF /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 4DED8D4B20575A9C001CA7DF /* Assets.xcassets */; };
 		4DED8D4F20575A9C001CA7DF /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 4DED8D4D20575A9C001CA7DF /* LaunchScreen.storyboard */; };
+		9CA589EF24AC4EA600AE4F07 /* AdSupport.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9CA589EB24AC4D2B00AE4F07 /* AdSupport.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -63,6 +64,7 @@
 		4DED8D4B20575A9C001CA7DF /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		4DED8D4E20575A9C001CA7DF /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		4DED8D5020575A9C001CA7DF /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		9CA589EB24AC4D2B00AE4F07 /* AdSupport.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AdSupport.framework; path = System/Library/Frameworks/AdSupport.framework; sourceTree = SDKROOT; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -71,6 +73,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				4DD0B42E20577289004ABA07 /* Virtusize.framework in Frameworks */,
+				9CA589EF24AC4EA600AE4F07 /* AdSupport.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -128,6 +131,7 @@
 		4DED8D5A20576946001CA7DF /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				9CA589EB24AC4D2B00AE4F07 /* AdSupport.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";

--- a/Source/Internal/API/APIRequest.swift
+++ b/Source/Internal/API/APIRequest.swift
@@ -1,7 +1,7 @@
 //
 //  APIRequest.swift
 //
-//  Copyright (c) 2018 Virtusize AB
+//  Copyright (c) 2018-20 Virtusize AB
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal
@@ -22,6 +22,7 @@
 //  THE SOFTWARE.
 //
 import Foundation
+import AdSupport
 
 internal typealias JSONObject = [String: Any]
 internal typealias JSONArray = [JSONObject]
@@ -49,7 +50,7 @@ internal struct APIRequest {
         return request
     }
 
-    /// Gets the `URLRequest` for the HTTP request where the Browser Identifier is added
+    /// Gets the `URLRequest` for the HTTP request where the Browser Identifier and a unique device ID are added
     ///
     /// - Parameters:
     ///   - components: `URLComponents` to obtain the `URL`
@@ -58,6 +59,9 @@ internal struct APIRequest {
     private static func apiRequest(components: URLComponents, method: APIMethod = .get) -> URLRequest {
         var request = HTTPRequest(components: components, method: method)
         request.addValue(BrowserID.current.identifier, forHTTPHeaderField: "x-vs-bid")
+        if let uniqueDeviceID = DeviceIdentifier.getUniqueDeviceId() {
+            request.addValue(uniqueDeviceID, forHTTPHeaderField: "x-vs-device-id")
+        }
         return request
     }
 

--- a/Source/Internal/API/APIRequest.swift
+++ b/Source/Internal/API/APIRequest.swift
@@ -22,7 +22,6 @@
 //  THE SOFTWARE.
 //
 import Foundation
-import AdSupport
 
 internal typealias JSONObject = [String: Any]
 internal typealias JSONArray = [JSONObject]

--- a/Source/Internal/Workers/ASIdentifierManager.swift
+++ b/Source/Internal/Workers/ASIdentifierManager.swift
@@ -1,0 +1,40 @@
+//
+//  ASIdentifierManager.swift
+//
+//  Copyright (c) 2018-20 Virtusize AB
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
+
+import Foundation
+
+/// A NSObject to get the `ASIdentifierManager` class without importing AdSupport in the SDK
+internal class ASIdentifierManager: NSObject {
+
+    @objc
+    internal dynamic var advertisingIdentifier: UUID? { return nil }
+
+    @objc
+    internal dynamic var isAdvertisingTrackingEnabled: Bool { return false }
+
+    @objc
+    internal dynamic class func sharedManager() -> ASIdentifierManager? {
+        return nil
+    }
+}

--- a/Source/Internal/Workers/DeviceIdentifier.swift
+++ b/Source/Internal/Workers/DeviceIdentifier.swift
@@ -1,0 +1,62 @@
+//
+//  DeviceIdentifier.swift
+//
+//  Copyright (c) 2018-20 Virtusize AB
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
+
+import Foundation
+
+/// This class is used to get a unique identifier to each device or each app from the same development team
+internal class DeviceIdentifier {
+
+    /// Gets the ASIdentifierManager class without importing AdSupport in the SDK
+    private static var advertisingIdentifierManager: ASIdentifierManager? = {
+        let selector = #selector(ASIdentifierManager.sharedManager)
+
+        guard let NSClass = NSClassFromString("ASIdentifierManager"),
+              let identifierManagerClass = NSClass as AnyObject as? NSObjectProtocol else {
+            return nil
+        }
+
+        guard identifierManagerClass.responds(to: selector) else {
+            return nil
+        }
+
+        let sharedManager = identifierManagerClass.perform(selector).takeUnretainedValue()
+
+        return unsafeBitCast(sharedManager, to: ASIdentifierManager.self)
+    }()
+
+    /// Gets a unique device identifier
+    ///
+    /// - Note: For IDFA to be available, a developer has to link in `AdSupport.framework`
+    ///
+    /// - Returns: `advertisingIdentifier` if it's available.
+    /// Otherwise, `identifierForVendor`, that is unique for the apps from the same development team
+    static func getUniqueDeviceId() -> String? {
+        if advertisingIdentifierManager?.isAdvertisingTrackingEnabled ?? false,
+            let idfa = advertisingIdentifierManager?.advertisingIdentifier?.uuidString,
+            idfa != "00000000-0000-0000-0000-000000000000" {
+            return idfa
+        }
+        return UIDevice.current.identifierForVendor?.uuidString
+    }
+}

--- a/Virtusize.xcodeproj/project.pbxproj
+++ b/Virtusize.xcodeproj/project.pbxproj
@@ -24,6 +24,8 @@
 		9C633F28249388EB009C4392 /* TestFixtures.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C633F27249388EB009C4392 /* TestFixtures.swift */; };
 		9C633F2A2493C7ED009C4392 /* VirtusizeProductImageMetaData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C633F292493C7ED009C4392 /* VirtusizeProductImageMetaData.swift */; };
 		9C7DA17324973FBD00AD6B42 /* APISessionProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C7DA17224973FBD00AD6B42 /* APISessionProtocol.swift */; };
+		9CA589E824AC46A100AE4F07 /* DeviceIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CA589E724AC46A100AE4F07 /* DeviceIdentifier.swift */; };
+		9CA589EA24AC4B9900AE4F07 /* ASIdentifierManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CA589E924AC4B9900AE4F07 /* ASIdentifierManager.swift */; };
 		9CB0390C24921FDA008CCD84 /* APIEventTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CB0390B24921FDA008CCD84 /* APIEventTests.swift */; };
 		DF6B5C9E219D151F000B3402 /* Assets.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF6B5C9D219D151F000B3402 /* Assets.swift */; };
 		DF6B5CA0219D3090000B3402 /* SplashView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF6B5C9F219D3090000B3402 /* SplashView.swift */; };
@@ -70,6 +72,8 @@
 		9C633F27249388EB009C4392 /* TestFixtures.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestFixtures.swift; sourceTree = "<group>"; };
 		9C633F292493C7ED009C4392 /* VirtusizeProductImageMetaData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VirtusizeProductImageMetaData.swift; sourceTree = "<group>"; };
 		9C7DA17224973FBD00AD6B42 /* APISessionProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APISessionProtocol.swift; sourceTree = "<group>"; };
+		9CA589E724AC46A100AE4F07 /* DeviceIdentifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceIdentifier.swift; sourceTree = "<group>"; };
+		9CA589E924AC4B9900AE4F07 /* ASIdentifierManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ASIdentifierManager.swift; sourceTree = "<group>"; };
 		9CB0390B24921FDA008CCD84 /* APIEventTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIEventTests.swift; sourceTree = "<group>"; };
 		DF6B5C9D219D151F000B3402 /* Assets.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = Assets.swift; path = Source/Internal/Constants/Assets.swift; sourceTree = "<group>"; };
 		DF6B5C9F219D3090000B3402 /* SplashView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplashView.swift; sourceTree = "<group>"; };
@@ -243,6 +247,8 @@
 			children = (
 				4D6C578D205FB6F400DA910E /* BrowserID.swift */,
 				DFFAA95921A2DF19000F0F70 /* Deserializer.swift */,
+				9CA589E724AC46A100AE4F07 /* DeviceIdentifier.swift */,
+				9CA589E924AC4B9900AE4F07 /* ASIdentifierManager.swift */,
 			);
 			path = Workers;
 			sourceTree = "<group>";
@@ -412,6 +418,7 @@
 				DF71642C21A28939002C7202 /* VirtusizeEnvironment.swift in Sources */,
 				DF6B5C9E219D151F000B3402 /* Assets.swift in Sources */,
 				4D6C578E205FB6F400DA910E /* BrowserID.swift in Sources */,
+				9CA589EA24AC4B9900AE4F07 /* ASIdentifierManager.swift in Sources */,
 				9C5956CD2484F6280014DF51 /* VirtusizeOrderItem.swift in Sources */,
 				9C633F2A2493C7ED009C4392 /* VirtusizeProductImageMetaData.swift in Sources */,
 				4D6C5798205FC0C700DA910E /* VirtusizeButton.swift in Sources */,
@@ -419,6 +426,7 @@
 				DF71642821A28501002C7202 /* VirtusizeError.swift in Sources */,
 				DFFAA95E21A39AC0000F0F70 /* APIEndpoints.swift in Sources */,
 				DFFAA95C21A39A75000F0F70 /* APIEvent.swift in Sources */,
+				9CA589E824AC46A100AE4F07 /* DeviceIdentifier.swift in Sources */,
 				DF71642E21A28DE8002C7202 /* VirtusizeProduct.swift in Sources */,
 				DF6B5CA0219D3090000B3402 /* SplashView.swift in Sources */,
 			);


### PR DESCRIPTION
## Summary

- [x] Pass a unique device ID with the "x-vs-device-id" header
- [ ] Update and save browser ID if bid in the response is different

Note: By default, the SDK collects **Identifier For Advertisers (IDFA)** only if a client app already uses it or enables the AdSupport.framework.
If the Advertising ID is not available or used by a client app, then **Identifier for Vendor (IDFV)**, whose value is the same for apps that come from the same development team, is collected instead.
However, it can be changed to collect IDFA even if a client app doesn't use it, but the client has to tick the IDFA usage checkboxes during the submission process. If the client forgets to tick it, the app will get rejected by Apple