### PR TITLE
Feature: Item x Item Comparison UI 

### DIFF
--- a/Colors.swift
+++ b/Colors.swift
@@ -31,5 +31,6 @@ final internal class Colors {
     internal static let gray900PressedColor: UIColor = #colorLiteral(red: 0.1960784314, green: 0.1960784314, blue: 0.1960784314, alpha: 1)
     internal static let vsTealColor: UIColor = #colorLiteral(red: 0.2431372549, green: 0.8235294118, blue: 0.7294117647, alpha: 1)
     internal static let vsTealPressedColor: UIColor = #colorLiteral(red: 0.4784313725, green: 0.8549019608, blue: 0.7490196078, alpha: 1)
+	internal static let vsDarkTealColor: UIColor = #colorLiteral(red: 0.0862745098, green: 0.7764705882, blue: 0.7254901961, alpha: 1)
     internal static let inPageShadowColor: UIColor = #colorLiteral(red: 0.8039215803, green: 0.8039215803, blue: 0.8039215803, alpha: 1)
 }

--- a/Example/Example.xcodeproj/project.pbxproj
+++ b/Example/Example.xcodeproj/project.pbxproj
@@ -407,7 +407,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = Example/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.3;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.virtusize.Example;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -423,7 +423,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = Example/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.3;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.virtusize.Example;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/Source/Internal/API/APIRequest.swift
+++ b/Source/Internal/API/APIRequest.swift
@@ -64,6 +64,7 @@ internal struct APIRequest {
 	private static func apiRequestWithAuthHeader(components: URLComponents) -> URLRequest {
 		var request = apiRequest(components: components, method: .post)
 		request.addValue(UserDefaultsHelper.current.authHeader ?? "", forHTTPHeaderField: "x-vs-auth")
+		request.addValue("", forHTTPHeaderField: "Cookie")
 		return request
 	}
 

--- a/Source/Internal/API/APIRequest.swift
+++ b/Source/Internal/API/APIRequest.swift
@@ -211,7 +211,7 @@ internal struct APIRequest {
     // TODO: comment
     internal static func getBodyProfileRecommendedSize(
         productTypes: [VirtusizeProductType],
-        storeProduct: VirtusizeStoreProduct,
+        storeProduct: VirtusizeInternalProduct,
         userBodyProfile: VirtusizeUserBodyProfile
     ) -> URLRequest? {
         let endpoint = APIEndpoints.getSize

--- a/Source/Internal/Constants/Assets.swift
+++ b/Source/Internal/Constants/Assets.swift
@@ -114,7 +114,7 @@ final internal class Assets {
     ///   - style: The product style, which is fetched from the store product info
     /// - Returns: The  product type placeholder`UIImage`
     static func getProductPlaceholderImage(productType: Int, style: String? = nil) -> UIImage? {
-        var placeholderImage = UIImage(bundleNamed: "\(productType)")
+		var placeholderImage = UIImage(bundleNamed: "\(productType)")
         if let style = style,
             let productTypeWithStyleImage = UIImage(bundleNamed: "\(productType)_\(style)") {
             placeholderImage = productTypeWithStyleImage

--- a/Source/Internal/Models/SizeComparisonRecommendedSize.swift
+++ b/Source/Internal/Models/SizeComparisonRecommendedSize.swift
@@ -26,7 +26,7 @@
 internal struct SizeComparisonRecommendedSize {
     var bestFitScore: Double
 	var bestSize: VirtusizeProductSize?
-    var bestUserProduct: VirtusizeStoreProduct?
+    var bestUserProduct: VirtusizeInternalProduct?
     var isStoreProductSmaller: Bool?
 
     init() {

--- a/Source/Internal/Models/SizeComparisonRecommendedSize.swift
+++ b/Source/Internal/Models/SizeComparisonRecommendedSize.swift
@@ -25,11 +25,13 @@
 // TODO: add comment
 internal struct SizeComparisonRecommendedSize {
     var bestFitScore: Double
+	var bestSize: VirtusizeProductSize?
     var bestUserProduct: VirtusizeStoreProduct?
     var isStoreProductSmaller: Bool?
 
     init() {
         bestFitScore = 0.0
+		bestSize = nil
         bestUserProduct = nil
         isStoreProductSmaller = false
     }

--- a/Source/Internal/Models/VirtusizeGetSizeParams.swift
+++ b/Source/Internal/Models/VirtusizeGetSizeParams.swift
@@ -38,7 +38,7 @@ internal struct VirtusizeGetSizeParams: Codable {
     }
 
     init(productTypes: [VirtusizeProductType],
-         storeProduct: VirtusizeStoreProduct,
+         storeProduct: VirtusizeInternalProduct,
          userBodyProfile: VirtusizeUserBodyProfile?
     ) {
         additionalInfo = [
@@ -66,7 +66,7 @@ internal struct VirtusizeGetSizeParams: Codable {
         userGender = userBodyProfile?.gender ?? ""
     }
 
-    private func getModelInfoDict(storeProduct: VirtusizeStoreProduct) -> [String: Any] {
+    private func getModelInfoDict(storeProduct: VirtusizeInternalProduct) -> [String: Any] {
         var modelInfoDict: [String: Any] = [:]
         if let modelInfo = storeProduct.storeProductMeta?.additionalInfo?.modelInfo {
             for (name, measurement) in modelInfo {
@@ -103,7 +103,7 @@ internal struct VirtusizeGetSizeParams: Codable {
         return bodyDataDict
     }
 
-    private func getItemSizesDict(storeProduct: VirtusizeStoreProduct) -> [String: [String: Int?]] {
+    private func getItemSizesDict(storeProduct: VirtusizeInternalProduct) -> [String: [String: Int?]] {
         var itemSizesDict: [String: [String: Int?]] = [:]
         for productSize in storeProduct.sizes {
             itemSizesDict[productSize.name ?? ""] = productSize.measurements

--- a/Source/Internal/Models/VirtusizeInternalProduct.swift
+++ b/Source/Internal/Models/VirtusizeInternalProduct.swift
@@ -1,5 +1,5 @@
 //
-//  VirtusizeStoreProduct.swift
+//  VirtusizeInternalProduct.swift
 //
 //  Copyright (c) 2020 Virtusize KK
 //
@@ -22,8 +22,8 @@
 //  THE SOFTWARE.
 //
 
-/// This structure represents a store product from the Virtusize server
-internal class VirtusizeStoreProduct: Codable {
+/// This structure represents a product from the Virtusize server
+internal class VirtusizeInternalProduct: Codable {
     // swiftlint:disable identifier_name
     /// An integer to represent the internal product ID in the Virtusize server
     let id: Int

--- a/Source/Internal/Models/VirtusizeStoreProduct.swift
+++ b/Source/Internal/Models/VirtusizeStoreProduct.swift
@@ -142,7 +142,7 @@ internal class VirtusizeStoreProduct: Codable {
         _ sizeComparisonRecommendedSize: SizeComparisonRecommendedSize?,
         _ bodyProfileRecommendedSizeName: String?
     ) -> String {
-		if let sizeComparisonRecommendedSizeName = sizeComparisonRecommendedSize?.bestUserProduct?.sizes[0].name {
+		if let sizeComparisonRecommendedSizeName = sizeComparisonRecommendedSize?.bestSize?.name {
 			return i18nLocalization.getSizeComparisonMultiSizeText(sizeComparisonRecommendedSizeName)
 		}
         if let bodyProfileRecommendedSizeName = bodyProfileRecommendedSizeName {

--- a/Source/Internal/Views/VirtusizeProductImageView.swift
+++ b/Source/Internal/Views/VirtusizeProductImageView.swift
@@ -26,9 +26,29 @@
 /// or replacing it with a product type placeholder image when the image URL is not available
 internal class VirtusizeProductImageView: UIView {
 
+	override var isHidden: Bool {
+		get {
+			return super.isHidden
+		}
+		set(value) {
+			super.isHidden = value
+			if value {
+				circleBorderLayer.isHidden = true
+			} else if productImageType == .USER {
+				circleBorderLayer.isHidden = false
+			}
+		}
+	}
+
+	enum ProductImageType {
+		case USER, STORE
+	}
+
     private var imageSize: CGFloat = 40
 
     private var productImageView: UIImageView = UIImageView()
+
+	private let circleBorderLayer = CAShapeLayer()
 
     var image: UIImage? {
         set {
@@ -42,6 +62,12 @@ internal class VirtusizeProductImageView: UIView {
         }
     }
 
+	var productImageType: ProductImageType = ProductImageType.STORE {
+		didSet {
+			setStyle()
+		}
+	}
+
     required init?(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)
         setup()
@@ -54,17 +80,31 @@ internal class VirtusizeProductImageView: UIView {
     }
 
     private func setup() {
+		backgroundColor = UIColor.white
         addSubview(productImageView)
-
-        frame = CGRect(x: 0, y: 0, width: imageSize, height: imageSize)
-        layer.cornerRadius = imageSize / 2
-        layer.borderWidth = 0.5
-        layer.borderColor = Colors.gray800Color.cgColor
 
         setStyle()
     }
 
     private func setStyle() {
+		frame = CGRect(x: 0, y: 0, width: imageSize, height: imageSize)
+		layer.cornerRadius = imageSize / 2
+
+		if productImageType == .STORE {
+			layer.borderWidth = 0.5
+			layer.borderColor = Colors.gray800Color.cgColor
+		} else {
+			circleBorderLayer.path = UIBezierPath(ovalIn: bounds).cgPath
+			circleBorderLayer.lineWidth = 2.0
+			circleBorderLayer.strokeColor = Colors.vsDarkTealColor.cgColor
+			circleBorderLayer.lineDashPattern = [4, 3]
+			circleBorderLayer.frame = bounds
+			circleBorderLayer.fillColor = nil
+			layer.borderColor = UIColor.white.cgColor
+			layer.addSublayer(circleBorderLayer)
+			layer.zPosition = 1
+		}
+
         productImageView.center = center
         productImageView.frame = CGRect(x: 2, y: 2, width: imageSize - 4, height: imageSize - 4)
         productImageView.layer.cornerRadius = (imageSize - 4) / 2
@@ -72,37 +112,37 @@ internal class VirtusizeProductImageView: UIView {
         productImageView.contentMode = .scaleAspectFill
     }
 
-    internal func setImage(storeProduct: VirtusizeStoreProduct, localImageUrl: URL?, completion: (() -> Void)? = nil) {
+    internal func setImage(product: VirtusizeInternalProduct, localImageUrl: URL?, completion: (() -> Void)? = nil) {
         if localImageUrl != nil {
-            loadImageUrl(url: localImageUrl!, storeProduct: storeProduct, success: {
+            loadImageUrl(url: localImageUrl!, product: product, success: {
                 completion?()
             }, failure: {
-                self.setImage(storeProduct: storeProduct, localImageUrl: nil, completion: completion)
+                self.setImage(product: product, localImageUrl: nil, completion: completion)
             })
             return
         }
-        if let remoteImageUrl = getCloudinaryImageUrl(storeProduct.cloudinaryPublicId) {
-            loadImageUrl(url: remoteImageUrl, storeProduct: storeProduct, success: {
+        if let remoteImageUrl = getCloudinaryImageUrl(product.cloudinaryPublicId) {
+            loadImageUrl(url: remoteImageUrl, product: product, success: {
                 completion?()
             }, failure: {
                 self.setProductTypeImage(
-                    productType: storeProduct.productType,
-                    style: storeProduct.storeProductMeta?.additionalInfo?.style
+                    productType: product.productType,
+                    style: product.storeProductMeta?.additionalInfo?.style
                 )
                 completion?()
             })
         } else {
             completion?()
             setProductTypeImage(
-                productType: storeProduct.productType,
-                style: storeProduct.storeProductMeta?.additionalInfo?.style
+                productType: product.productType,
+                style: product.storeProductMeta?.additionalInfo?.style
             )
         }
     }
 
     private func loadImageUrl(
         url: URL,
-        storeProduct: VirtusizeStoreProduct,
+        product: VirtusizeInternalProduct,
         success: (() -> Void)? = nil,
         failure: (() -> Void)? = nil
     ) {
@@ -127,20 +167,13 @@ internal class VirtusizeProductImageView: UIView {
         self.productImageView.image = Assets.getProductPlaceholderImage(
             productType: productType,
             style: style
-        )?.withPadding(inset: 6)
+        )?.withPadding(inset: 6)?.withRenderingMode(.alwaysTemplate)
         self.productImageView.contentMode = .scaleAspectFit
-        self.productImageView.backgroundColor = Colors.gray200Color
-    }
-
-    internal func showCircleBorder() {
-        layer.cornerRadius = imageSize / 2
-        layer.borderWidth = 0.5
-        productImageView.layer.cornerRadius = (imageSize - 4) / 2
-    }
-
-    internal func hideCircleBorder() {
-        layer.cornerRadius = 0
-        layer.borderWidth = 0
-        productImageView.layer.cornerRadius = 0
+		if productImageType == .STORE {
+			self.productImageView.backgroundColor = Colors.gray200Color
+		} else {
+			self.productImageView.backgroundColor = UIColor.white
+			self.productImageView.tintColor = Colors.vsTealColor
+		}
     }
 }

--- a/Source/Internal/Views/VirtusizeProductImageView.swift
+++ b/Source/Internal/Views/VirtusizeProductImageView.swift
@@ -32,10 +32,10 @@ internal class VirtusizeProductImageView: UIView {
 		}
 		set(value) {
 			super.isHidden = value
-			if value {
-				circleBorderLayer.isHidden = true
-			} else if productImageType == .USER {
+			if !value && productImageType == .USER {
 				circleBorderLayer.isHidden = false
+			} else {
+				circleBorderLayer.isHidden = true
 			}
 		}
 	}
@@ -167,10 +167,10 @@ internal class VirtusizeProductImageView: UIView {
         self.productImageView.image = Assets.getProductPlaceholderImage(
             productType: productType,
             style: style
-        )?.withPadding(inset: 6)?.withRenderingMode(.alwaysTemplate)
-        self.productImageView.contentMode = .scaleAspectFit
+        )?.withPadding(inset: 8)?.withRenderingMode(.alwaysTemplate)
 		if productImageType == .STORE {
 			self.productImageView.backgroundColor = Colors.gray200Color
+			self.productImageView.tintColor = UIColor.black
 		} else {
 			self.productImageView.backgroundColor = UIColor.white
 			self.productImageView.tintColor = Colors.vsTealColor

--- a/Source/Internal/Views/VirtusizeProductImageView.swift
+++ b/Source/Internal/Views/VirtusizeProductImageView.swift
@@ -109,7 +109,7 @@ internal class VirtusizeProductImageView: UIView {
         productImageView.frame = CGRect(x: 2, y: 2, width: imageSize - 4, height: imageSize - 4)
         productImageView.layer.cornerRadius = (imageSize - 4) / 2
         productImageView.layer.masksToBounds = true
-        productImageView.contentMode = .scaleAspectFill
+		productImageView.contentMode = .scaleAspectFit
     }
 
     internal func setImage(product: VirtusizeInternalProduct, localImageUrl: URL?, completion: (() -> Void)? = nil) {

--- a/Source/Internal/Workers/FindBestFitHelper.swift
+++ b/Source/Internal/Workers/FindBestFitHelper.swift
@@ -23,7 +23,7 @@
 //
 
 // TODO: add comment
-class FindBestFitHelper {
+internal class FindBestFitHelper {
 
     static func findBestMatchedProductSize(
         userProducts: [VirtusizeStoreProduct],
@@ -45,6 +45,7 @@ class FindBestFitHelper {
                 )
                 if storeProductFitInfo.fitScore > sizeComparisonRecommendedSize.bestFitScore {
                     sizeComparisonRecommendedSize.bestFitScore = storeProductFitInfo.fitScore
+					sizeComparisonRecommendedSize.bestSize = storeProductSize
                     sizeComparisonRecommendedSize.bestUserProduct = userProduct
                     sizeComparisonRecommendedSize.isStoreProductSmaller = storeProductFitInfo.isSmaller
                 }

--- a/Source/Internal/Workers/FindBestFitHelper.swift
+++ b/Source/Internal/Workers/FindBestFitHelper.swift
@@ -26,8 +26,8 @@
 internal class FindBestFitHelper {
 
     static func findBestMatchedProductSize(
-        userProducts: [VirtusizeStoreProduct],
-        storeProduct: VirtusizeStoreProduct,
+        userProducts: [VirtusizeInternalProduct],
+        storeProduct: VirtusizeInternalProduct,
         productTypes: [VirtusizeProductType]
     ) -> SizeComparisonRecommendedSize? {
         let storeProductType = productTypes.first(where: { $0.id == storeProduct.productType })

--- a/Source/Internal/Workers/UserDefaultsHelper.swift
+++ b/Source/Internal/Workers/UserDefaultsHelper.swift
@@ -28,6 +28,7 @@ import Foundation
 final internal class UserDefaultsHelper {
 
 	let authKey = "VIRTUSIZE_AUTH"
+	let tokenKey = "VIRTUSIZE_TOKEN"
 	let bidKey = "BID"
 
     /// A static instance of `UserDefaultsHelper` used inside the SDK
@@ -53,6 +54,16 @@ final internal class UserDefaultsHelper {
 		}
 		set {
 			defaults.setValue(newValue, forKey: authKey)
+			defaults.synchronize()
+		}
+	}
+	
+	internal var accessToken: String? {
+		get {
+			return defaults.value(forKey: tokenKey) as? String
+		}
+		set {
+			defaults.setValue(newValue, forKey: tokenKey)
 			defaults.synchronize()
 		}
 	}

--- a/Source/Models/VirtusizeParams.swift
+++ b/Source/Models/VirtusizeParams.swift
@@ -71,7 +71,7 @@ public class VirtusizeParams {
         paramsScript += "\(ParamKey.detailsPanelCards): \(detailsPanelCards.map { category in category.rawValue }), "
         paramsScript += "\(ParamKey.language): '\(language.rawValue)', "
         paramsScript += "\(ParamKey.region): '\(region.rawValue)', "
-        paramsScript += "\(ParamKey.environment): 'production'})"
+		paramsScript += "\(ParamKey.environment): '\(Virtusize.environment == .staging ? "staging" : "production")'})"
         return paramsScript
     }
 

--- a/Source/UI/VirtusizeInPageMini.swift
+++ b/Source/UI/VirtusizeInPageMini.swift
@@ -59,15 +59,12 @@ public class VirtusizeInPageMini: VirtusizeInPageView {
     }
 
     public override func setInPageText() {
-        guard let storeProduct = Virtusize.storeProduct,
-              let i18nLocalization = Virtusize.i18nLocalization else {
-            self.showErrorScreen()
-            return
-        }
+		super.setInPageText()
+
         setLoadingScreen(loading: false)
         inPageMiniMessageLabel.attributedText = NSAttributedString(string:
-            storeProduct.getRecommendationText(
-                i18nLocalization,
+		    Virtusize.storeProduct!.getRecommendationText(
+				Virtusize.i18nLocalization!,
 				Virtusize.sizeComparisonRecommendedSize,
 				Virtusize.bodyProfileRecommendedSize?.sizeName,
                 VirtusizeI18nLocalization.TrimType.ONELINE
@@ -211,7 +208,7 @@ public class VirtusizeInPageMini: VirtusizeInPageView {
         inPageMiniSizeCheckButton.isHidden = loading ? true: false
     }
 
-    private func showErrorScreen() {
+	internal override func showErrorScreen() {
         backgroundColor = .white
         stopLoadingAnimation()
         inPageMiniImageView.image = Assets.errorHanger

--- a/Source/UI/VirtusizeInPageMini.swift
+++ b/Source/UI/VirtusizeInPageMini.swift
@@ -58,8 +58,8 @@ public class VirtusizeInPageMini: VirtusizeInPageView {
         setLoadingScreen(loading: true)
     }
 
-    public override func setInPageText() {
-		super.setInPageText()
+    public override func updateInPageTextAndView() {
+		super.updateInPageTextAndView()
 
         setLoadingScreen(loading: false)
         inPageMiniMessageLabel.attributedText = NSAttributedString(string:

--- a/Source/UI/VirtusizeInPageStandard.swift
+++ b/Source/UI/VirtusizeInPageStandard.swift
@@ -37,8 +37,8 @@ public class VirtusizeInPageStandard: VirtusizeInPageView {
 	private var metrics: [String: CGFloat] = [:]
     private let inPageStandardView: UIView = UIView()
 	private let vsIconImageView: UIImageView = UIImageView(frame: CGRect(x: 0, y: 0, width: 30, height: 20))
-    private let leftProductImageView: VirtusizeProductImageView = VirtusizeProductImageView(size: 40)
-	private let rightProductImageView: VirtusizeProductImageView = VirtusizeProductImageView(size: 40)
+    private let userProductImageView: VirtusizeProductImageView = VirtusizeProductImageView(size: 40)
+	private let storeProductImageView: VirtusizeProductImageView = VirtusizeProductImageView(size: 40)
     private let messageStackView: UIStackView = UIStackView()
     private let topMessageLabel: UILabel = UILabel()
     private let bottomMessageLabel: UILabel = UILabel()
@@ -49,11 +49,12 @@ public class VirtusizeInPageStandard: VirtusizeInPageView {
     private let errorText: UILabel = UILabel()
 
     private var messageLineSpacing: CGFloat = 6
-	private var leftProjectImageSize: CGFloat = 0
+	private var userProjectImageSize: CGFloat = 0
 	private var productImageViewOffset: CGFloat = 0
 	private var minimumInPageWidthForTwoThumbnails: CGFloat = 343
 
 	private var loadingImageSemaphore = DispatchSemaphore(value: 1)
+	private var storeProductImageIsSet = false
 
     public func setupHorizontalMargin(view: UIView, margin: CGFloat) {
         setHorizontalMargins(view: view, margin: margin)
@@ -80,8 +81,8 @@ public class VirtusizeInPageStandard: VirtusizeInPageView {
         addSubview(inPageStandardView)
         addSubview(vsSignatureImageView)
         addSubview(privacyPolicyLink)
-		inPageStandardView.addSubview(leftProductImageView)
-        inPageStandardView.addSubview(rightProductImageView)
+		inPageStandardView.addSubview(userProductImageView)
+        inPageStandardView.addSubview(storeProductImageView)
 		inPageStandardView.addSubview(vsIconImageView)
         inPageStandardView.addSubview(messageStackView)
         messageStackView.addArrangedSubview(topMessageLabel)
@@ -93,12 +94,13 @@ public class VirtusizeInPageStandard: VirtusizeInPageView {
 
     // swiftlint:disable function_body_length
     private func setConstraints() {
+		translatesAutoresizingMaskIntoConstraints = false
         inPageStandardView.translatesAutoresizingMaskIntoConstraints = false
 		vsIconImageView.translatesAutoresizingMaskIntoConstraints = false
         vsSignatureImageView.translatesAutoresizingMaskIntoConstraints = false
         privacyPolicyLink.translatesAutoresizingMaskIntoConstraints = false
-		leftProductImageView.translatesAutoresizingMaskIntoConstraints = false
-        rightProductImageView.translatesAutoresizingMaskIntoConstraints = false
+		userProductImageView.translatesAutoresizingMaskIntoConstraints = false
+        storeProductImageView.translatesAutoresizingMaskIntoConstraints = false
         messageStackView.translatesAutoresizingMaskIntoConstraints = false
         bottomMessageLabel.translatesAutoresizingMaskIntoConstraints = false
         bottomMessageLabel.translatesAutoresizingMaskIntoConstraints = false
@@ -111,8 +113,8 @@ public class VirtusizeInPageStandard: VirtusizeInPageView {
 			"vsIconImageView": vsIconImageView,
             "virtusizeImageView": vsSignatureImageView,
             "privacyPolicyLink": privacyPolicyLink,
-			"leftProductImageView": leftProductImageView,
-            "rightProductImageView": rightProductImageView,
+			"userProductImageView": userProductImageView,
+            "storeProductImageView": storeProductImageView,
             "messageStackView": messageStackView,
             "topMessageLabel": topMessageLabel,
             "bottomMessageLabel": bottomMessageLabel,
@@ -123,7 +125,7 @@ public class VirtusizeInPageStandard: VirtusizeInPageView {
 
 	    metrics = [
 			"defaultMargin": defaultMargin,
-			"leftProjectImageSize": leftProjectImageSize,
+			"userProjectImageSize": userProjectImageSize,
 			"productImageViewOffset": productImageViewOffset
         ]
 
@@ -171,7 +173,7 @@ public class VirtusizeInPageStandard: VirtusizeInPageView {
 
         // swiftlint:disable line_length
 		let inPageStandardViewsHorizontalConstraints = NSLayoutConstraint.constraints(
-            withVisualFormat: "H:|-defaultMargin-[leftProductImageView(==leftProjectImageSize)]-(productImageViewOffset)-[rightProductImageView(==40)]-defaultMargin-[messageStackView]-(>=defaultMargin)-[checkSizeButton]-defaultMargin-|",
+            withVisualFormat: "H:|-defaultMargin-[userProductImageView(==userProjectImageSize)]-(productImageViewOffset)-[storeProductImageView(==40)]-defaultMargin-[messageStackView]-(>=defaultMargin)-[checkSizeButton]-defaultMargin-|",
             options: NSLayoutConstraint.FormatOptions(rawValue: 0),
             metrics: metrics,
             views: views
@@ -185,14 +187,14 @@ public class VirtusizeInPageStandard: VirtusizeInPageView {
 		)
 
         let leftProductImageViewVerticalConstraints = NSLayoutConstraint.constraints(
-            withVisualFormat: "V:|-(>=14)-[leftProductImageView(==40)]-(>=14)-|",
+            withVisualFormat: "V:|-(>=14)-[userProductImageView(==40)]-(>=14)-|",
             options: NSLayoutConstraint.FormatOptions(rawValue: 0),
             metrics: nil,
             views: views
         )
 
-		let rightProductImageViewVerticalConstraints = NSLayoutConstraint.constraints(
-			withVisualFormat: "V:|-(>=14)-[rightProductImageView(==40)]-(>=14)-|",
+		let storeProductImageViewVerticalConstraints = NSLayoutConstraint.constraints(
+			withVisualFormat: "V:|-(>=14)-[storeProductImageView(==40)]-(>=14)-|",
 			options: NSLayoutConstraint.FormatOptions(rawValue: 0),
 			metrics: nil,
 			views: views
@@ -227,7 +229,7 @@ public class VirtusizeInPageStandard: VirtusizeInPageView {
 		addConstraints(inPageStandardViewsHorizontalConstraints)
         addConstraints(footerHorizontalConstraints)
         addConstraints(leftProductImageViewVerticalConstraints)
-		addConstraints(rightProductImageViewVerticalConstraints)
+		addConstraints(storeProductImageViewVerticalConstraints)
         addConstraints(messageStackViewVerticalConstraints)
         addConstraints(checkSizeButtonVerticalConstraints)
         addConstraints(errorScreenVerticalConstraints)
@@ -235,8 +237,8 @@ public class VirtusizeInPageStandard: VirtusizeInPageView {
         addConstraints(errorTextHorizontalConstraints)
 
 		addConstraint(vsIconImageView.centerYAnchor.constraint(equalTo: inPageStandardView.centerYAnchor))
-		addConstraint(leftProductImageView.centerYAnchor.constraint(equalTo: inPageStandardView.centerYAnchor))
-        addConstraint(rightProductImageView.centerYAnchor.constraint(equalTo: inPageStandardView.centerYAnchor))
+		addConstraint(userProductImageView.centerYAnchor.constraint(equalTo: inPageStandardView.centerYAnchor))
+        addConstraint(storeProductImageView.centerYAnchor.constraint(equalTo: inPageStandardView.centerYAnchor))
         addConstraint(messageStackView.centerYAnchor.constraint(equalTo: inPageStandardView.centerYAnchor))
         addConstraint(checkSizeButton.centerYAnchor.constraint(equalTo: inPageStandardView.centerYAnchor))
         addConstraint(errorImageView.centerXAnchor.constraint(equalTo: inPageStandardView.centerXAnchor))
@@ -254,8 +256,8 @@ public class VirtusizeInPageStandard: VirtusizeInPageView {
 
 		vsIconImageView.image = Assets.icon
 
-		leftProductImageView.productImageType = .USER
-		rightProductImageView.productImageType = .STORE
+		userProductImageView.productImageType = .USER
+		storeProductImageView.productImageType = .STORE
 
         vsSignatureImageView.image = Assets.vsSignature
 
@@ -340,55 +342,57 @@ public class VirtusizeInPageStandard: VirtusizeInPageView {
     }
 
 	public override func setInPageText() {
-		guard let storeProduct = Virtusize.storeProduct,
-			  let i18nLocalization = Virtusize.i18nLocalization else {
-			self.showErrorScreen()
-			return
-		}
+		super.setInPageText()
 
 		let semaphore = DispatchSemaphore(value: 0)
 
-		DispatchQueue.global(qos: .background).async {
+		DispatchQueue.global().async {
 			let bestFitUserProduct = Virtusize.sizeComparisonRecommendedSize?.bestUserProduct
 			if bestFitUserProduct != nil {
-				self.leftProductImageView.setImage(product: bestFitUserProduct!, localImageUrl: nil) {
+				self.userProductImageView.setImage(product: bestFitUserProduct!, localImageUrl: nil) {
 					semaphore.signal()
 				}
 				semaphore.wait()
-				self.rightProductImageView.setImage(product: storeProduct, localImageUrl: Virtusize.product?.imageURL) {
+				if !self.storeProductImageIsSet {
+					self.storeProductImageView.setImage(product: Virtusize.storeProduct!, localImageUrl: Virtusize.product?.imageURL) {
+						self.storeProductImageIsSet = true
+						semaphore.signal()
+					}
+					semaphore.wait()
+				}
+				DispatchQueue.main.async {
+					if self.inPageStandardView.frame.size.width >= self.minimumInPageWidthForTwoThumbnails {
+						self.removeConstraints(self.constraints)
+						self.userProjectImageSize = 40
+						self.productImageViewOffset = -2
+						self.setConstraints()
+					}
+				}
+			} else {
+				self.storeProductImageView.setImage(product: Virtusize.storeProduct!, localImageUrl: Virtusize.product?.imageURL) {
 					semaphore.signal()
 				}
 				semaphore.wait()
 				DispatchQueue.main.async {
 					if self.inPageStandardView.frame.size.width >= self.minimumInPageWidthForTwoThumbnails {
 						self.removeConstraints(self.constraints)
-						self.translatesAutoresizingMaskIntoConstraints = true
-						self.leftProjectImageSize = 40
-						self.productImageViewOffset = -2
+						self.userProjectImageSize = 0
+						self.productImageViewOffset = 0
 						self.setConstraints()
 					}
 				}
-			} else {
-				DispatchQueue.main.async {
-					self.leftProductImageView.isHidden = true
-				}
-				self.rightProductImageView.setImage(product: storeProduct, localImageUrl: Virtusize.product?.imageURL) {
-					semaphore.signal()
-				}
-				semaphore.wait()
 			}
 			DispatchQueue.main.async {
-				print("\(self.inPageStandardView.frame.size.width)")
-				if self.inPageStandardView.frame.size.width < self.minimumInPageWidthForTwoThumbnails {
-					self.crossFadeBetweenTwoProductImages(self.leftProductImageView, self.rightProductImageView)
+				if self.inPageStandardView.frame.size.width < self.minimumInPageWidthForTwoThumbnails && bestFitUserProduct != nil {
+					self.crossFadeBetweenTwoProductImages(self.userProductImageView, self.storeProductImageView)
 				}
 				self.setMessageLabelTexts(
-					storeProduct,
-					i18nLocalization,
+					Virtusize.storeProduct!,
+					Virtusize.i18nLocalization!,
 					Virtusize.sizeComparisonRecommendedSize,
 					Virtusize.bodyProfileRecommendedSize?.sizeName
 				)
-				self.setLoadingScreen(loading: false)
+				self.setLoadingScreen(loading: false, bestFitUserProduct: bestFitUserProduct)
 			}
 		}
 	}
@@ -432,19 +436,20 @@ public class VirtusizeInPageStandard: VirtusizeInPageView {
             ).lineSpacing(self.messageLineSpacing)
         } else {
             self.topMessageLabel.isHidden = true
+			self.topMessageLabel.text = ""
             self.bottomMessageLabel.attributedText = NSAttributedString(
                 string: recommendationText
             ).lineSpacing(self.messageLineSpacing)
         }
     }
 
-    private func setLoadingScreen(loading: Bool) {
+	private func setLoadingScreen(loading: Bool, bestFitUserProduct: VirtusizeInternalProduct? = nil) {
         vsSignatureImageView.isHidden = loading ? true : false
         privacyPolicyLink.isHidden = loading ? true : false
         topMessageLabel.isHidden = loading ? true : false
 		vsIconImageView.isHidden = loading ? false : true
-		leftProductImageView.isHidden = loading ? true : false
-		rightProductImageView.isHidden = loading ? true : false
+		userProductImageView.isHidden = (loading || bestFitUserProduct == nil) ? true : false
+		storeProductImageView.isHidden = loading ? true : false
         if loading {
             startLoadingAnimation(
                 label: bottomMessageLabel,
@@ -455,12 +460,12 @@ public class VirtusizeInPageStandard: VirtusizeInPageView {
         }
     }
 
-    private func showErrorScreen() {
+	internal override func showErrorScreen() {
         inPageStandardView.layer.shadowOpacity = 0
         inPageStandardView.isUserInteractionEnabled = false
 		vsIconImageView.isHidden = true
-		leftProductImageView.isHidden = true
-        rightProductImageView.isHidden = true
+		userProductImageView.isHidden = true
+        storeProductImageView.isHidden = true
         bottomMessageLabel.isHidden = true
         checkSizeButton.isHidden = true
         errorImageView.isHidden = false

--- a/Source/UI/VirtusizeInPageView.swift
+++ b/Source/UI/VirtusizeInPageView.swift
@@ -87,7 +87,7 @@ public class VirtusizeInPageView: UIView, VirtusizeView {
 		openVirtusizeWebView(eventHandler: virtusizeEventHandler)
     }
 
-	internal func setInPageText() {
+	internal func updateInPageTextAndView() {
 		guard Virtusize.storeProduct != nil,
 			  Virtusize.i18nLocalization != nil else {
 			showErrorScreen()

--- a/Source/UI/VirtusizeInPageView.swift
+++ b/Source/UI/VirtusizeInPageView.swift
@@ -22,6 +22,7 @@
 //  THE SOFTWARE.
 //
 public class VirtusizeInPageView: UIView, VirtusizeView {
+	internal var virtusizeEventHandler: VirtusizeEventHandler?
 
     /// The property to set the Virtusize view style that this SDK provides
     public var style: VirtusizeViewStyle = VirtusizeViewStyle.NONE {
@@ -32,7 +33,6 @@ public class VirtusizeInPageView: UIView, VirtusizeView {
 
     public var presentingViewController: UIViewController?
     public var messageHandler: VirtusizeMessageHandler?
-    public func setInPageText() {}
 
     internal let defaultMargin: CGFloat = 8
 
@@ -40,12 +40,14 @@ public class VirtusizeInPageView: UIView, VirtusizeView {
 
     required init?(coder: NSCoder) {
         super.init(coder: coder)
+		virtusizeEventHandler = self
         isHidden = true
         setup()
     }
 
     public override init(frame: CGRect) {
         super.init(frame: .zero)
+		virtusizeEventHandler = self
         isHidden = true
         setup()
     }
@@ -82,8 +84,18 @@ public class VirtusizeInPageView: UIView, VirtusizeView {
     }
 
     @objc internal func clickInPageViewAction() {
-        openVirtusizeWebView()
+		openVirtusizeWebView(eventHandler: virtusizeEventHandler)
     }
+
+	internal func setInPageText() {
+		guard Virtusize.storeProduct != nil,
+			  Virtusize.i18nLocalization != nil else {
+			showErrorScreen()
+			return
+		}
+	}
+
+	internal func showErrorScreen() {}
 
     internal func startLoadingAnimation(label: UILabel, text: String) {
         var tempDots = 0
@@ -102,4 +114,44 @@ public class VirtusizeInPageView: UIView, VirtusizeView {
     internal func stopLoadingAnimation() {
         timer?.invalidate()
     }
+}
+
+extension VirtusizeInPageView: VirtusizeEventHandler {
+
+	public func userAuthData(bid: String?, auth: String?) {
+		if let bid = bid {
+			UserDefaultsHelper.current.identifier = bid
+		}
+		if let auth = auth,
+		   !auth.isEmpty {
+			UserDefaultsHelper.current.authHeader = auth
+		}
+	}
+
+	public func userLoggedIn() {
+		DispatchQueue.global().async {
+			Virtusize.updateSession()
+			Virtusize.setupRecommendation()
+		}
+	}
+
+	public func userLoggedOut() {
+		UserDefaultsHelper.current.authHeader = ""
+		DispatchQueue.global().async {
+			Virtusize.updateSession()
+			Virtusize.setupRecommendation()
+		}
+	}
+
+	public func userSelectedProduct(userProductId: Int?) {
+		DispatchQueue.global().async {
+			Virtusize.setupRecommendation(selectedUserProductId: userProductId)
+		}
+	}
+
+	public func userAddedProduct() {
+		DispatchQueue.global().async {
+			Virtusize.setupRecommendation()
+		}
+	}
 }

--- a/Source/UI/VirtusizeInPageView.swift
+++ b/Source/UI/VirtusizeInPageView.swift
@@ -139,7 +139,7 @@ extension VirtusizeInPageView: VirtusizeEventHandler {
 		UserDefaultsHelper.current.authHeader = ""
 		DispatchQueue.global().async {
 			Virtusize.updateSession()
-			Virtusize.setupRecommendation()
+			Virtusize.setupRecommendation(selectedUserProductId: nil, loggedOutUser: true)
 		}
 	}
 

--- a/Source/UI/VirtusizeView.swift
+++ b/Source/UI/VirtusizeView.swift
@@ -38,8 +38,12 @@ public protocol VirtusizeView {
 extension VirtusizeView {
 
     /// Opens the Virtusize web view
-    internal func openVirtusizeWebView() {
-        if let virtusize = VirtusizeWebViewController(handler: messageHandler, processPool: Virtusize.processPool) {
+	internal func openVirtusizeWebView(eventHandler: VirtusizeEventHandler? = nil) {
+		if let virtusize = VirtusizeWebViewController(
+			messageHandler: messageHandler,
+			eventHandler: eventHandler,
+			processPool: Virtusize.processPool
+		) {
             presentingViewController?.present(virtusize, animated: true, completion: nil)
         }
     }

--- a/Source/Virtusize.swift
+++ b/Source/Virtusize.swift
@@ -67,7 +67,9 @@ public class Virtusize {
     typealias ErrorHandler = (VirtusizeError) -> Void
 
 	/// Todo
-	internal static var authToken: String?
+	internal static var authToken: String? {
+		return UserDefaultsHelper.current.accessToken
+	}
 
 	/// The array of `VirtusizeView` that clients use on their mobile application
 	private static var virtusizeViews: [VirtusizeView] = []
@@ -209,7 +211,12 @@ public class Virtusize {
 
 	internal class func updateSession() {
 		let userSessionInfoResponse = Virtusize.getUserSessionInfoAsync()
-		authToken = userSessionInfoResponse.success?.id
+		if let accessToken = userSessionInfoResponse.success?.id {
+			UserDefaultsHelper.current.accessToken = accessToken
+		}
+		if let authHeader = userSessionInfoResponse.success?.authHeader, !authHeader.isEmpty {
+			UserDefaultsHelper.current.authHeader = authHeader
+		}
 	}
 
 	internal class func setupRecommendation(selectedUserProductId: Int? = nil, loggedOutUser: Bool = false) {

--- a/Source/Virtusize.swift
+++ b/Source/Virtusize.swift
@@ -212,9 +212,15 @@ public class Virtusize {
 		authToken = userSessionInfoResponse.success?.id
 	}
 
-	internal class func setupRecommendation(selectedUserProductId: Int? = nil) {
-		let userProducts = Virtusize.getUserProductsAsync().success
-		let userBodyProfile = Virtusize.getUserBodyProfileAsync().success
+	internal class func setupRecommendation(selectedUserProductId: Int? = nil, loggedOutUser: Bool = false) {
+		var userProducts: [VirtusizeInternalProduct]?
+		var userBodyProfile: VirtusizeUserBodyProfile?
+		bodyProfileRecommendedSize = nil
+		sizeComparisonRecommendedSize = nil
+		if !loggedOutUser {
+			userProducts = Virtusize.getUserProductsAsync().success
+			userBodyProfile = Virtusize.getUserBodyProfileAsync().success
+		}
 		if userProducts != nil && productTypes != nil && storeProduct != nil && userBodyProfile != nil {
 			bodyProfileRecommendedSize = Virtusize.getBodyProfileRecommendedSizeAsync(
 				productTypes: productTypes!,
@@ -227,9 +233,6 @@ public class Virtusize {
 				storeProduct: storeProduct!,
 				productTypes: productTypes!
 			)
-		} else {
-			bodyProfileRecommendedSize = nil
-			sizeComparisonRecommendedSize = nil
 		}
 		DispatchQueue.main.async {
 			for index in 0...virtusizeViews.count-1 {

--- a/Source/Virtusize.swift
+++ b/Source/Virtusize.swift
@@ -95,17 +95,18 @@ public class Virtusize {
 					return
 				}
 				_product = product
-				if let productId = _product!.productCheckData?.productDataId {
-					for index in 0...virtusizeViews.count-1 {
-						virtusizeViews[index].isLoading()
-					}
-					DispatchQueue.global().async {
-						storeProduct = Virtusize.getStoreProductInfoAsync(productId: productId).success
-						productTypes = Virtusize.getProductTypesAsync().success
-						i18nLocalization = Virtusize.getI18nTextsAsync().success
-						updateSession()
-						setupRecommendation()
-					}
+				guard let productId = _product!.productCheckData?.productDataId else {
+					return
+				}
+				for index in 0...virtusizeViews.count-1 {
+					virtusizeViews[index].isLoading()
+				}
+				DispatchQueue.global().async {
+					storeProduct = Virtusize.getStoreProductInfoAsync(productId: productId).success
+					productTypes = Virtusize.getProductTypesAsync().success
+					i18nLocalization = Virtusize.getI18nTextsAsync().success
+					updateSession()
+					setupRecommendation()
 				}
 			})
 		}
@@ -228,22 +229,22 @@ public class Virtusize {
 			userProducts = Virtusize.getUserProductsAsync().success
 			userBodyProfile = Virtusize.getUserBodyProfileAsync().success
 		}
-		if userProducts != nil && productTypes != nil && storeProduct != nil && userBodyProfile != nil {
+		if let userProducts = userProducts, let productTypes = productTypes, let storeProduct = storeProduct, let userBodyProfile = userBodyProfile {
 			bodyProfileRecommendedSize = Virtusize.getBodyProfileRecommendedSizeAsync(
-				productTypes: productTypes!,
-				storeProduct: storeProduct!,
-				userBodyProfile: userBodyProfile!
+				productTypes: productTypes,
+				storeProduct: storeProduct,
+				userBodyProfile: userBodyProfile
 			).success
 			sizeComparisonRecommendedSize = FindBestFitHelper.findBestMatchedProductSize(
-				userProducts: selectedUserProductId != nil ? userProducts!.filter({ product in
-					return product.id == selectedUserProductId }) : userProducts!,
-				storeProduct: storeProduct!,
-				productTypes: productTypes!
+				userProducts: selectedUserProductId != nil ? userProducts.filter({ product in
+					return product.id == selectedUserProductId }) : userProducts,
+				storeProduct: storeProduct,
+				productTypes: productTypes
 			)
 		}
 		DispatchQueue.main.async {
 			for index in 0...virtusizeViews.count-1 {
-				(virtusizeViews[index] as? VirtusizeInPageView)?.setInPageText()
+				(virtusizeViews[index] as? VirtusizeInPageView)?.updateInPageTextAndView()
 			}
 		}
 	}

--- a/Source/Virtusize.swift
+++ b/Source/Virtusize.swift
@@ -51,7 +51,7 @@ public class Virtusize {
     /// Allow process pool to be set to share cookies
     public static var processPool: WKProcessPool?
 
-	internal static var storeProduct: VirtusizeStoreProduct?
+	internal static var storeProduct: VirtusizeInternalProduct?
 	internal static var i18nLocalization: VirtusizeI18nLocalization?
 	internal static var bodyProfileRecommendedSize: BodyProfileRecommendedSize?
 	internal static var sizeComparisonRecommendedSize: SizeComparisonRecommendedSize?
@@ -206,7 +206,7 @@ public class Virtusize {
         task.resume()
         URLSession.shared.finishTasksAndInvalidate()
 
-        _ = semaphore.wait(timeout: .distantFuture)
+		_ = semaphore.wait(timeout: .distantFuture)
 
         guard apiResponse != nil else {
             return apiResponse
@@ -381,11 +381,11 @@ public class Virtusize {
     /// - Parameters:
     ///   - productId: The internal product ID from the Virtusize server
     /// - Return:
-    internal class func getStoreProductInfoAsync(productId: Int) -> APIResult<VirtusizeStoreProduct> {
+    internal class func getStoreProductInfoAsync(productId: Int) -> APIResult<VirtusizeInternalProduct> {
         guard let request = APIRequest.getStoreProductInfo(productId: productId) else {
             return .failure(nil)
         }
-        return getAPIResultAsync(request: request, type: VirtusizeStoreProduct.self)
+        return getAPIResultAsync(request: request, type: VirtusizeInternalProduct.self)
     }
 
     /// The API request for getting the list of all the product types from the Virtusize server
@@ -413,11 +413,11 @@ public class Virtusize {
 	/// - Parameters:
 	///   - onSuccess: A callback to pass `[VirtusizeStoreProduct]` when the request is successful
 	///   - onError: A callback to pass `VirtusizeError` back when the request is unsuccessful
-	internal class func getUserProductsAsync() -> APIResult<[VirtusizeStoreProduct]> {
+	internal class func getUserProductsAsync() -> APIResult<[VirtusizeInternalProduct]> {
 		guard let request = APIRequest.getUserProducts() else {
 			return .failure(nil)
 		}
-		return getAPIResultAsync(request: request, type: [VirtusizeStoreProduct].self)
+		return getAPIResultAsync(request: request, type: [VirtusizeInternalProduct].self)
 	}
 
 	// TODO: add comment
@@ -430,7 +430,7 @@ public class Virtusize {
 
 	internal class func getBodyProfileRecommendedSizeAsync(
 		productTypes: [VirtusizeProductType],
-		storeProduct: VirtusizeStoreProduct,
+		storeProduct: VirtusizeInternalProduct,
 		userBodyProfile: VirtusizeUserBodyProfile
 	) -> APIResult<BodyProfileRecommendedSize> {
 		guard let request = APIRequest.getBodyProfileRecommendedSize(

--- a/Tests/FindBestFitHelperTests.swift
+++ b/Tests/FindBestFitHelperTests.swift
@@ -158,8 +158,8 @@ class FindBestFitHelperTests: XCTestCase {
     private static func getStoreProduct(
         productId: Int,
         sizes: [VirtusizeProductSize]
-    ) -> VirtusizeStoreProduct {
-        return VirtusizeStoreProduct(
+    ) -> VirtusizeInternalProduct {
+        return VirtusizeInternalProduct(
             id: productId,
             sizes: sizes,
             externalId: "",

--- a/Tests/StoreProductFixtures.swift
+++ b/Tests/StoreProductFixtures.swift
@@ -24,9 +24,9 @@
 
 extension TestFixtures {
 
-	static func getOneSizeProduct() -> VirtusizeStoreProduct? {
+	static func getOneSizeProduct() -> VirtusizeInternalProduct? {
 		return try? JSONDecoder().decode(
-			VirtusizeStoreProduct.self,
+			VirtusizeInternalProduct.self,
 			from: Data(
 				TestFixtures.getStoreProductJsonResponse(
 					productType: 8,
@@ -65,9 +65,9 @@ extension TestFixtures {
             "height": 165
         """,
         gender: String?
-    ) -> VirtusizeStoreProduct? {
+    ) -> VirtusizeInternalProduct? {
         return try? JSONDecoder().decode(
-            VirtusizeStoreProduct.self,
+            VirtusizeInternalProduct.self,
             from: Data(
                 TestFixtures.getStoreProductJsonResponse(
                     productType: productType,

--- a/Tests/VirtusizeGetSizeParamsTests.swift
+++ b/Tests/VirtusizeGetSizeParamsTests.swift
@@ -249,8 +249,6 @@ class VirtusizeGetSizeParamsTests: XCTestCase {
             return
         }
 
-        print(String(decoding: try JSONEncoder().encode(actualGetSizeParams), as: UTF8.self))
-
         guard let expectedDict = expectedJsonObject as? NSDictionary else {
             XCTFail("Failed casting expected JSON object (i.e. \(expectedJsonObject)) to an NSDictionary")
             return

--- a/Tests/VirtusizeStoreProductTests.swift
+++ b/Tests/VirtusizeStoreProductTests.swift
@@ -50,7 +50,7 @@ class VirtusizeStoreProductTests: XCTestCase {
     }
 
     func testDecoding_validStoreProductData_shouldReturnExpectedStructure() {
-        let storeProduct = try? JSONDecoder().decode(VirtusizeStoreProduct.self, from: storeProductFixture)
+        let storeProduct = try? JSONDecoder().decode(VirtusizeInternalProduct.self, from: storeProductFixture)
 
         XCTAssertEqual(storeProduct?.id, TestFixtures.productId)
         XCTAssertEqual(storeProduct?.sizes.count, 3)
@@ -70,7 +70,7 @@ class VirtusizeStoreProductTests: XCTestCase {
 
     func testDecoding_emptyJsonData_shouldReturnNil() {
         let storeProduct = try? JSONDecoder().decode(
-            VirtusizeStoreProduct.self,
+			VirtusizeInternalProduct.self,
             from: Data(TestFixtures.emptyResponse.utf8)
         )
 
@@ -193,7 +193,7 @@ class VirtusizeStoreProductTests: XCTestCase {
 	func testGetRecommendationText_multiSizeProduct_hasSizeComparisonRecommendedSize_returnMultiSizeComparisonText() {
 		let storeProduct1 = TestFixtures.getStoreProduct(productType: 1, gender: nil)
 		var sizeComparisonRecommendedSize = SizeComparisonRecommendedSize()
-		sizeComparisonRecommendedSize.bestUserProduct = storeProduct1
+		sizeComparisonRecommendedSize.bestSize = storeProduct1?.sizes[0]
 		XCTAssertTrue(
 			storeProduct1!.getRecommendationText(
 				i18nLocalization,

--- a/Tests/VirtusizeTests.swift
+++ b/Tests/VirtusizeTests.swift
@@ -205,7 +205,7 @@ class VirtusizeTests: XCTestCase {
 
     func testGetStoreProductInfo_withValidProductId_hasExpectedStoreProduct() {
         let expectation = self.expectation(description: "Virtusize.getStoreProductInfo reaches the callback")
-        var actualStoreProduct: VirtusizeStoreProduct?
+        var actualStoreProduct: VirtusizeInternalProduct?
 
         Virtusize.session = MockURLSession(
             data: TestFixtures.getStoreProductJsonResponse(gender: nil).data(using: .utf8),
@@ -281,7 +281,7 @@ class VirtusizeTests: XCTestCase {
 
     func testGetUserProducts_hasExpectedUserProductList() {
         let expectation = self.expectation(description: "Virtusize.getUserProducts reaches the callback")
-        var actualUserProductList: [VirtusizeStoreProduct]?
+        var actualUserProductList: [VirtusizeInternalProduct]?
 
         Virtusize.session = MockURLSession(
             data: TestFixtures.userProductArrayJsonResponse.data(using: .utf8),
@@ -326,7 +326,7 @@ class VirtusizeTests: XCTestCase {
 
     func testGetUserProducts_userHasAnEmptyWardrobe_hasExpectedEmptyUserProductList() {
         let expectation = self.expectation(description: "Virtusize.getUserProducts reaches the callback")
-        var actualUserProductList: [VirtusizeStoreProduct]?
+        var actualUserProductList: [VirtusizeInternalProduct]?
 
         Virtusize.session = MockURLSession(
             data: TestFixtures.emptyProductArrayJsonResponse.data(using: .utf8),

--- a/Virtusize.xcodeproj/project.pbxproj
+++ b/Virtusize.xcodeproj/project.pbxproj
@@ -84,7 +84,7 @@
 		9CEAB7C024D9582E00F969E1 /* VirtusizeStoreProductMetaTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CEAB7BE24D9560D00F969E1 /* VirtusizeStoreProductMetaTests.swift */; };
 		9CEAB7C424D95A8100F969E1 /* VirtusizeProductSize.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CEAB7C324D95A8100F969E1 /* VirtusizeProductSize.swift */; };
 		9CEAB7C724D95CFF00F969E1 /* VirtusizeProductSizeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CEAB7C524D95CFD00F969E1 /* VirtusizeProductSizeTests.swift */; };
-		9CEAB7C924D9676200F969E1 /* VirtusizeStoreProduct.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CEAB7C824D9676200F969E1 /* VirtusizeStoreProduct.swift */; };
+		9CEAB7C924D9676200F969E1 /* VirtusizeInternalProduct.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CEAB7C824D9676200F969E1 /* VirtusizeInternalProduct.swift */; };
 		9CEAB7CC24D967BA00F969E1 /* VirtusizeStoreProductTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CEAB7CA24D967B800F969E1 /* VirtusizeStoreProductTests.swift */; };
 		9CEC8D852529CF58001CBDFB /* FindBestFitHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CEC8D842529CF58001CBDFB /* FindBestFitHelper.swift */; };
 		9CEC8D8C252AB963001CBDFB /* StoreProductFitInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CEC8D8B252AB963001CBDFB /* StoreProductFitInfo.swift */; };
@@ -189,7 +189,7 @@
 		9CEAB7BE24D9560D00F969E1 /* VirtusizeStoreProductMetaTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VirtusizeStoreProductMetaTests.swift; sourceTree = "<group>"; };
 		9CEAB7C324D95A8100F969E1 /* VirtusizeProductSize.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VirtusizeProductSize.swift; sourceTree = "<group>"; };
 		9CEAB7C524D95CFD00F969E1 /* VirtusizeProductSizeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VirtusizeProductSizeTests.swift; sourceTree = "<group>"; };
-		9CEAB7C824D9676200F969E1 /* VirtusizeStoreProduct.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VirtusizeStoreProduct.swift; sourceTree = "<group>"; };
+		9CEAB7C824D9676200F969E1 /* VirtusizeInternalProduct.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VirtusizeInternalProduct.swift; sourceTree = "<group>"; };
 		9CEAB7CA24D967B800F969E1 /* VirtusizeStoreProductTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VirtusizeStoreProductTests.swift; sourceTree = "<group>"; };
 		9CEC8D842529CF58001CBDFB /* FindBestFitHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FindBestFitHelper.swift; sourceTree = "<group>"; };
 		9CEC8D8B252AB963001CBDFB /* StoreProductFitInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreProductFitInfo.swift; sourceTree = "<group>"; };
@@ -416,7 +416,7 @@
 				9CEAB7B724D940CE00F969E1 /* VirtusizeStoreProductAdditionalInfo.swift */,
 				9CEAB7BC24D943F400F969E1 /* VirtusizeStoreProductMeta.swift */,
 				9CEAB7C324D95A8100F969E1 /* VirtusizeProductSize.swift */,
-				9CEAB7C824D9676200F969E1 /* VirtusizeStoreProduct.swift */,
+				9CEAB7C824D9676200F969E1 /* VirtusizeInternalProduct.swift */,
 				9C6DDE1C24DAE50E0021073A /* VirtusizeProductType.swift */,
 				9C6DDE2A24DCF2270021073A /* VirtusizeProductCheckData.swift */,
 				9C6DDE2D24DCF2A70021073A /* VirtusizeUserData.swift */,
@@ -691,7 +691,7 @@
 				9C58752024EF7DC200352474 /* VirtusizeViewStyle.swift in Sources */,
 				9C106EEE24FF99390012EE51 /* String+Extensions.swift in Sources */,
 				4D6C5793205FB9BA00DA910E /* Virtusize.swift in Sources */,
-				9CEAB7C924D9676200F969E1 /* VirtusizeStoreProduct.swift in Sources */,
+				9CEAB7C924D9676200F969E1 /* VirtusizeInternalProduct.swift in Sources */,
 				9C58751E24EF7D5000352474 /* VirtusizeView.swift in Sources */,
 				9C4378D7253444F600E8729A /* UserSessionInfo.swift in Sources */,
 				DF71642821A28501002C7202 /* VirtusizeError.swift in Sources */,
@@ -899,7 +899,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = Source/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.3;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MARKETING_VERSION = 2.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.virtusize.Virtusize;
@@ -921,7 +921,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = Source/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.3;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MARKETING_VERSION = 2.0.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.virtusize.Virtusize;

--- a/Virtusize.xcodeproj/project.pbxproj
+++ b/Virtusize.xcodeproj/project.pbxproj
@@ -388,7 +388,6 @@
 				9CF9666924F41191001D3458 /* Font.swift */,
 				9CB2DD5C24F4BD24004D4E08 /* Image+Extensions.swift */,
 				9C106EED24FF99390012EE51 /* String+Extensions.swift */,
-				9CEC8D842529CF58001CBDFB /* FindBestFitHelper.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -476,6 +475,7 @@
 		DFFAA96121A39BBE000F0F70 /* Workers */ = {
 			isa = PBXGroup;
 			children = (
+				9CEC8D842529CF58001CBDFB /* FindBestFitHelper.swift */,
 				4D6C578D205FB6F400DA910E /* UserDefaultsHelper.swift */,
 				DFFAA95921A2DF19000F0F70 /* Deserializer.swift */,
 			);


### PR DESCRIPTION
## Summary
- [x] Fix displaying the wrong recommended size info
- [x] Display product thumbnails with crossfade animation when the width of InPage is below 411dp
- [x] Handle different scenarios when an event, such as "user-selected-product", "user-added-product", "user-logged-in", "user-logged-out", and so on, is sent from Aoyama to SDK

## Demo
![Oct-27-2020 13-42-45](https://user-images.githubusercontent.com/7802052/97257803-56f5ba80-185a-11eb-9d79-57ae3e293b8e.gif)

**When the width of InPage is smaller than 343pt**
**Note:** Due to the session issue, I need to log in to Aoyama every time I open it for now.
![Oct-27-2020 13-46-11](https://user-images.githubusercontent.com/7802052/97258020-cff51200-185a-11eb-903e-470411c40935.gif)

### Examples of UI changes based on different user events from the web view
Device: iPhone 5s simulator, whose InPage width is smaller than 343pt
**Note:** Due to the session issue, I need to log in to Aoyama every time I open it for now.

***A user logs in***
![Oct-27-2020 13-47-38](https://user-images.githubusercontent.com/7802052/97258094-016ddd80-185b-11eb-8649-c13a669469a6.gif)

***A user logs out***
![Oct-27-2020 13-50-11](https://user-images.githubusercontent.com/7802052/97258502-e3ed4380-185b-11eb-807b-0f824e6621d9.gif)

***A user selects a different product***
![Oct-27-2020 13-55-11](https://user-images.githubusercontent.com/7802052/97258632-2b73cf80-185c-11eb-9c5b-6626970dc05a.gif)



