### PR TITLE
Feature: Change the event API URL

### DIFF
--- a/Source/Internal/API/APIEndpoints.swift
+++ b/Source/Internal/API/APIEndpoints.swift
@@ -47,7 +47,7 @@ internal enum APIEndpoints {
             components.path = "/rest-api/v1/product-meta-data-hints"
 
         case .events:
-            components.path = "/a/api/v3/events"
+			break
 
         case .virtusize(let region):
             components.host = "static.api.virtusize.\(region.rawValue)"
@@ -66,7 +66,9 @@ internal enum APIEndpoints {
     var hostname: String {
         if case .productDataCheck = self {
             return Virtusize.environment.productDataCheckUrl()
-        }
+		} else if case .events = self {
+			return Virtusize.environment.eventApiUrl()
+		}
         return Virtusize.environment.rawValue
     }
 

--- a/Source/Models/VirtusizeEnvironment.swift
+++ b/Source/Models/VirtusizeEnvironment.swift
@@ -34,6 +34,20 @@ public enum VirtusizeEnvironment: String {
         return "services.virtusize.com"
     }
 
+	/// Gets the event API URL corresponding to the Virtusize environment
+	internal func eventApiUrl() -> String {
+		switch self {
+		case .staging:
+			return "events.staging.virtusize.jp"
+		case .japan:
+			return "events.virtusize.jp"
+		case .global:
+			return "events.virtusize.com"
+		case .korea:
+			return "events.virtusize.kr"
+		}
+	}
+
     /// Gets the `VirtusizeRegion` corresponding to the Virtusize environment
     internal func virtusizeRegion() -> VirtusizeRegion {
         switch self {

--- a/Tests/APIEndpointsTests.swift
+++ b/Tests/APIEndpointsTests.swift
@@ -67,8 +67,8 @@ class APIEndpointsTests: XCTestCase {
     func testEventsEndpoint_returnExpectedComponents() {
         Virtusize.environment = .korea
         let endpoint = APIEndpoints.events
-        XCTAssertEqual(endpoint.components.host, "api.virtusize.kr")
-        XCTAssertEqual(endpoint.components.path, "/a/api/v3/events")
+        XCTAssertEqual(endpoint.components.host, "events.virtusize.kr")
+        XCTAssertEqual(endpoint.components.path, "")
 
         XCTAssertNil(endpoint.components.queryItems)
     }

--- a/Tests/APIEventTests.swift
+++ b/Tests/APIEventTests.swift
@@ -52,8 +52,8 @@ class APIEventTests: XCTestCase {
                        UIDevice.current.orientation.isLandscape ? "landscape" : "portrait"
         )
         XCTAssertEqual(payloadJson?["browserResolution"], "\(Int(screenSize.height))x\(Int(screenSize.width))")
-        XCTAssertEqual(payloadJson?["integrationVersion"], "0.2")
-        XCTAssertEqual(payloadJson?["snippetVersion"], "0.2")
+        XCTAssertEqual(payloadJson?["integrationVersion"], "0.0")
+        XCTAssertEqual(payloadJson?["snippetVersion"], "0.0")
     }
 
     func testAPIEventAlighProductDataCheckContext_hasExpectedPayload() {


### PR DESCRIPTION
Update the event API URL to "https://events.staging.virtusize.jp" for staging and "https://events.virtusize.{env}" for production
