### PR TITLE
Hotfix/2.1.2: Ensure dismissing the Virtusize web view by the SDK

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,7 +14,7 @@ Use list notation, and following prefixes:
 ## NEXT RELEASE for Version 2.x.x
 
 ### 2.1.2
-- Feature: Remove virtusizeControllerShouldClose to make VirtusizeMessageHandler optional
+- Feature: Ensure dismissing the Virtusize page by the SDK
 
 ### 2.1.1
 - Bugfix: Ensure localization resources and font files are in Virtusize.framework

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,9 @@ Use list notation, and following prefixes:
 
 ## NEXT RELEASE for Version 2.x.x
 
+### 2.1.2
+- Feature: Remove virtusizeControllerShouldClose to make VirtusizeMessageHandler optional
+
 ### 2.1.1
 - Bugfix: Ensure localization resources and font files are in Virtusize.framework
 

--- a/Example/Example/ViewController.swift
+++ b/Example/Example/ViewController.swift
@@ -159,10 +159,6 @@ class ViewController: UIViewController {
 }
 
 extension ViewController: VirtusizeMessageHandler {
-    func virtusizeControllerShouldClose(_ controller: VirtusizeWebViewController) {
-        dismiss(animated: true, completion: nil)
-    }
-
     func virtusizeController(_ controller: VirtusizeWebViewController, didReceiveEvent event: VirtusizeEvent) {
         print(event)
         switch event.name {
@@ -177,6 +173,5 @@ extension ViewController: VirtusizeMessageHandler {
 
     func virtusizeController(_ controller: VirtusizeWebViewController, didReceiveError error: VirtusizeError) {
         print(error)
-        dismiss(animated: true, completion: nil)
     }
 }

--- a/README-JP.md
+++ b/README-JP.md
@@ -84,7 +84,7 @@ $ carthage update
 
 ## セットアップ
 
-#### 1. はじめに
+### 1. はじめに
 
 Virtusizeのプロパティをアプリのdelegateの`application(_:didFinishLaunchingWithOptions:)`に設定します。
 
@@ -127,7 +127,7 @@ func application(_ application: UIApplication, didFinishLaunchingWithOptions lau
 
 
 
-### 2. **商品詳細をセットする**
+### 2. 商品詳細をセットする
 
 商品詳細ページのビューコントローラでは、製品の詳細を設定する必要があります。
 
@@ -148,20 +148,15 @@ override func viewDidLoad() {
 
 
 
-### 3. VirtusizeMessageHandlerの実装
+### 3. VirtusizeMessageHandlerの実装（オプション）
 
-`VirtusizeMessageHandler`プロトコルには3つの必須メソッドがあります。
+`VirtusizeMessageHandler`プロトコルには2つの必須メソッドがあります。
 
 - `virtusizeController(_:didReceiveError:)`はコントローラがネットワークエラーやデシリアライズエラーを報告する際に呼び出されます。
 - `virtusizeController(_:didReceiveEvent:)`はコントローラとVirtusize APIの間でデータが交換されたときに呼び出されます。`VirtusizeEvent`は必須の名前（`name`）とオプションのデータ（`data`）プロパティを持つ構造体（`struct`）です。
-- `virtusizeControllerShouldClose(_)`はコントローラが退出を要求する際に呼び出されます。
 
 ```Swift
 extension ViewController: VirtusizeMessageHandler {
-    func virtusizeControllerShouldClose(_ controller: VirtusizeWebViewController) {
-        dismiss(animated: true, completion: nil)
-    }
-
     func virtusizeController(_ controller: VirtusizeWebViewController, didReceiveEvent event: VirtusizeEvent) {
         print(event)
         switch event.name {
@@ -175,14 +170,14 @@ extension ViewController: VirtusizeMessageHandler {
     }
 
     func virtusizeController(_ controller: VirtusizeWebViewController, didReceiveError error: VirtusizeError) {
-        dismiss(animated: true, completion: nil)
+        print(error)
     }
 }
 ```
 
 
 
-### 4. **クッキー共有の許可（オプション）**
+### 4. クッキー共有の許可（オプション）
 
 `VirtusizeWebViewController` はオプションで `processPool:WKProcessPool` パラメーターを受け取り、クッキーの共有を許可します。
 
@@ -193,7 +188,7 @@ Virtusize.processPool = WKProcessPool()
 
 
 
-### 5. **製品データチェックを聞く（オプション）**
+### 5. 製品データチェックを聞く（オプション）
 
 ボタンが `externalId` で初期化されると、SDK は製品が解析されてデータベースに追加されたかどうかをチェックするために API を呼び出します。
 

--- a/README-JP.md
+++ b/README-JP.md
@@ -47,7 +47,7 @@ platform :ios, '10.3'
 use_frameworks!
 
 target '<your-target-name>' do
-pod 'Virtusize', '~> 2.1.1'
+pod 'Virtusize', '~> 2.1.2'
 end
 ```
 

--- a/README.md
+++ b/README.md
@@ -144,21 +144,16 @@ override func viewDidLoad() {
 }
 ```
 
-### 3. Implement VirtusizeMessageHandler
+### 3. Implement VirtusizeMessageHandler (Optional)
 
-The `VirtusizeMessageHandler`  protocol has three required methods:
+The `VirtusizeMessageHandler`  protocol has two required methods:
 
 - `virtusizeController(_:didReceiveError:)` is called when the controller is reporting a network or deserialisation error.
 - `virtusizeController(_:didReceiveEvent:)` is called when data is exchanged between
   the controller and the Virtusize API. `VirtusizeEvent` is a `struct` with a required `name` and an optional `data` property.
-- `virtusizeControllerShouldClose(_) `is called when the controller is requesting to be dismissed.
 
 ```Swift
 extension ViewController: VirtusizeMessageHandler {
-    func virtusizeControllerShouldClose(_ controller: VirtusizeWebViewController) {
-        dismiss(animated: true, completion: nil)
-    }
-
     func virtusizeController(_ controller: VirtusizeWebViewController, didReceiveEvent event: VirtusizeEvent) {
         print(event)
         switch event.name {
@@ -172,7 +167,7 @@ extension ViewController: VirtusizeMessageHandler {
     }
 
     func virtusizeController(_ controller: VirtusizeWebViewController, didReceiveError error: VirtusizeError) {
-        dismiss(animated: true, completion: nil)
+        print(error)
     }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ platform :ios, '10.3'
 use_frameworks!
 
 target '<your-target-name>' do
-pod 'Virtusize', '~> 2.1.1'
+pod 'Virtusize', '~> 2.1.2'
 end
 ```
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,6 +1,6 @@
 # ROADMAP
 
-## 2.1.0
+## 2.1.1
 
 ### Release date: 
 

--- a/Source/UI/VirtusizeWebViewController.swift
+++ b/Source/UI/VirtusizeWebViewController.swift
@@ -30,7 +30,6 @@ import WebKit
 public protocol VirtusizeMessageHandler: class {
     func virtusizeController(_ controller: VirtusizeWebViewController, didReceiveError error: VirtusizeError)
     func virtusizeController(_ controller: VirtusizeWebViewController, didReceiveEvent event: VirtusizeEvent)
-    func virtusizeControllerShouldClose(_ controller: VirtusizeWebViewController)
 }
 
 /// This `UIViewController` represents the Virtusize Window
@@ -128,11 +127,12 @@ public final class VirtusizeWebViewController: UIViewController {
     // MARK: Error Handling
     public func reportError(error: VirtusizeError) {
         messageHandler?.virtusizeController(self, didReceiveError: error)
+		dismiss(animated: true, completion: nil)
     }
 
     // MARK: Closing view
     @objc internal func shouldClose() {
-        messageHandler?.virtusizeControllerShouldClose(self)
+		dismiss(animated: true, completion: nil)
     }
 }
 

--- a/Virtusize.podspec
+++ b/Virtusize.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name = 'Virtusize'
-  s.version = '2.1.1'
+  s.version = '2.1.2'
   s.license = { :type => 'Copyright', :text => 'Copyright 2021 Virtusize' }
   s.summary = 'Integrate Virtusize on iOS devices'
   s.homepage = 'https://www.virtusize.com/'


### PR DESCRIPTION
# Summary
- [x] Make VirtusizeMessageHandler optional by dismissing the Virtusize web view automatically by the SDK instead of letting clients to implement the dismiss function. 
virtusizeControllerShouldClose is removed from VirtusizeMessageHandler since it won't be needed.
- [x] Bump version to 2.1.2