### PR TITLE
Fix: the wrong InPage message when a user logs out

### DIFF
--- a/Source/Internal/API/APIEndpoints.swift
+++ b/Source/Internal/API/APIEndpoints.swift
@@ -33,6 +33,7 @@ internal enum APIEndpoints {
     case storeProducts(productId: Int)
 	case productTypes
 	case sessions
+	case user
 	case userProducts
 	case userBodyMeasurements
     case getSize
@@ -76,6 +77,9 @@ internal enum APIEndpoints {
 
         case .sessions:
 			components.path = "/a/api/v3/sessions"
+
+        case .user:
+			components.path = "/a/api/v3/users/me"
 
         case .userProducts:
             components.path = "/a/api/v3/user-products"

--- a/Source/Internal/API/APIRequest.swift
+++ b/Source/Internal/API/APIRequest.swift
@@ -27,7 +27,7 @@ internal typealias JSONArray = [JSONObject]
 
 /// This enum contains supported HTTP request methods
 internal enum APIMethod: String {
-    case get = "GET", post = "POST"
+    case get = "GET", post = "POST", delete = "DELETE"
 }
 
 /// A structure to get `URLRequest`s for Virtusize API requests
@@ -65,8 +65,8 @@ internal struct APIRequest {
 	/// - Parameters:
 	///   - components: `URLComponents` to obtain the `URL`
 	/// - Returns: A `URLRequest` for this HTTP request
-	private static func apiRequestWithAuthHeader(components: URLComponents) -> URLRequest {
-		var request = apiRequest(components: components, method: .post)
+	private static func apiRequestWithAuthHeader(components: URLComponents, method: APIMethod = .post) -> URLRequest {
+		var request = apiRequest(components: components, method: method)
 		request.addValue(UserDefaultsHelper.current.authToken ?? "", forHTTPHeaderField: "x-vs-auth")
 		request.addValue("", forHTTPHeaderField: "Cookie")
 		return request
@@ -84,6 +84,7 @@ internal struct APIRequest {
 			return request
 		}
         request.addValue("Token \(accessToken)", forHTTPHeaderField: "Authorization")
+		request.addValue("", forHTTPHeaderField: "Cookie")
         return request
     }
 
@@ -203,6 +204,11 @@ internal struct APIRequest {
 	internal static func getSessions() -> URLRequest? {
 		let endpoint = APIEndpoints.sessions
 		return apiRequestWithAuthHeader(components: endpoint.components)
+	}
+
+	internal static func deleteUserData() -> URLRequest? {
+		let endpoint = APIEndpoints.user
+		return apiRequestWithAuthHeader(components: endpoint.components, method: .delete)
 	}
 
     /// Gets the `URLRequest` for the `storeProducts` request

--- a/Source/Internal/API/APIRequest.swift
+++ b/Source/Internal/API/APIRequest.swift
@@ -84,7 +84,6 @@ internal struct APIRequest {
 			return request
 		}
         request.addValue("Token \(accessToken)", forHTTPHeaderField: "Authorization")
-		request.addValue("", forHTTPHeaderField: "Cookie")
         return request
     }
 

--- a/Source/Internal/API/VirtusizeAPIService.swift
+++ b/Source/Internal/API/VirtusizeAPIService.swift
@@ -286,6 +286,13 @@ internal class VirtusizeAPIService {
 		return getAPIResultAsync(request: request, type: UserSessionInfo.self)
 	}
 
+	internal static func deleteUserDataAsync() -> APIResult<String> {
+		guard let request = APIRequest.deleteUserData() else {
+			return .failure(nil)
+		}
+		return getAPIResultAsync(request: request, type: nil)
+	}
+
 	/// The API request for getting the list of user products from the Virtusize server
 	///
 	/// - Returns: the user product data in the type of `VirtusizeInternalProduct`

--- a/Source/UI/VirtusizeInPageView.swift
+++ b/Source/UI/VirtusizeInPageView.swift
@@ -178,7 +178,7 @@ extension VirtusizeInPageView: VirtusizeEventHandler {
 		DispatchQueue.global().async {
 			VirtusizeRepository.shared.clearUserData()
 			VirtusizeRepository.shared.updateUserSession()
-			VirtusizeRepository.shared.fetchDataForInPageRecommendation()
+			VirtusizeRepository.shared.fetchDataForInPageRecommendation(shouldUpdateUserProducts: false)
 			VirtusizeRepository.shared.switchInPageRecommendation()
 		}
 	}

--- a/Source/VirtusizeRepository.swift
+++ b/Source/VirtusizeRepository.swift
@@ -183,8 +183,8 @@ internal class VirtusizeRepository: NSObject {
 
 	/// Clear user session and the data related to size recommendations
 	internal func clearUserData() {
+		_ = VirtusizeAPIService.deleteUserDataAsync()
 		UserDefaultsHelper.current.authToken = ""
-		UserDefaultsHelper.current.deleteIdentifier()
 
 		userProducts = nil
 		sizeComparisonRecommendedSize = nil

--- a/Source/VirtusizeRepository.swift
+++ b/Source/VirtusizeRepository.swift
@@ -184,6 +184,7 @@ internal class VirtusizeRepository: NSObject {
 	/// Clear user session and the data related to size recommendations
 	internal func clearUserData() {
 		UserDefaultsHelper.current.authToken = ""
+		UserDefaultsHelper.current.deleteIdentifier()
 
 		userProducts = nil
 		sizeComparisonRecommendedSize = nil


### PR DESCRIPTION
## Description
When a user logs out of Aoyama, the SDK will make an API call to `/user-products` to re-fetch user items. the product list is expected to be empty from the server, but in fact, the product list includes the items that the user has created before they log in and then log out, which causes InPage does not display "Find the right size ..." when a user logs out.

## Summary
- [x] Delete the user data when a user is logged out by making an API call to DELETE /users/me after a user logs out to delete the anonymous user with items
- [x] Disable fetching user products when a user logs out. 