### PR TITLE
Hotfix/2.1.6

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,10 @@ Use list notation, and following prefixes:
 
 ## NEXT RELEASE for Version 2.x.x
 
+### 2.1.6
+- Bugfix: Fix a crash related to com.apple.root.default-qos
+- Bugfix: Fix InPage loading the wrong product issue when there are multiple product pages opened in the navigation stack of a mobile app
+
 ### 2.1.5
 - Bugfix: Adjust the shadow of InPage
 

--- a/README-JP.md
+++ b/README-JP.md
@@ -47,7 +47,7 @@ platform :ios, '10.3'
 use_frameworks!
 
 target '<your-target-name>' do
-pod 'Virtusize', '~> 2.1.5'
+pod 'Virtusize', '~> 2.1.6'
 end
 ```
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ platform :ios, '10.3'
 use_frameworks!
 
 target '<your-target-name>' do
-pod 'Virtusize', '~> 2.1.5'
+pod 'Virtusize', '~> 2.1.6'
 end
 ```
 

--- a/Source/Internal/Utils/Image+Extensions.swift
+++ b/Source/Internal/Utils/Image+Extensions.swift
@@ -51,26 +51,3 @@ internal extension UIImage {
         return imageWithInsets
     }
 }
-
-internal extension UIImageView {
-
-    /// Loads the image from a URL
-    ///
-    /// - Parameters:
-    ///   - url: The image URL
-    ///   - success: The successful callback to pass the loaded image
-    ///   - failure: The failure callback
-    func load(url: URL, success: ((UIImage) -> Void)? = nil, failure: (() -> Void)? = nil) {
-		DispatchQueue.global().async {
-            if let data = try? Data(contentsOf: url), let image = UIImage(data: data) {
-                DispatchQueue.main.async {
-                    success?(image)
-                }
-            } else {
-                DispatchQueue.main.async {
-                    failure?()
-                }
-            }
-        }
-    }
-}

--- a/Source/Internal/Views/VirtusizeProductImageView.swift
+++ b/Source/Internal/Views/VirtusizeProductImageView.swift
@@ -110,7 +110,7 @@ internal class VirtusizeProductImageView: UIView {
         productImageView.frame = CGRect(x: 2, y: 2, width: imageSize - 4, height: imageSize - 4)
         productImageView.layer.cornerRadius = (imageSize - 4) / 2
         productImageView.layer.masksToBounds = true
-		productImageView.contentMode = .scaleAspectFit
+		productImageView.contentMode = .scaleAspectFill
     }
 
 	func setProductTypeImage(image: UIImage?) {
@@ -121,5 +121,6 @@ internal class VirtusizeProductImageView: UIView {
 			self.productImageView.backgroundColor = UIColor.white
 			self.productImageView.tintColor = .vsTealColor
 		}
+		productImageView.contentMode = .scaleAspectFit
     }
 }

--- a/Source/Models/VirtusizeParams.swift
+++ b/Source/Models/VirtusizeParams.swift
@@ -57,7 +57,7 @@ public class VirtusizeParams {
         guard let apiKey = Virtusize.APIKey else {
             fatalError("Please set Virtusize.APIKey")
         }
-		guard let storeProductId = Virtusize.currentProduct?.externalId else {
+		guard let storeProductId = VirtusizeRepository.shared.currentProduct?.externalId else {
             fatalError("The store product ID is invalid")
         }
         paramsScript += "{\(ParamKey.API): '\(apiKey)', "

--- a/Source/Models/VirtusizeParams.swift
+++ b/Source/Models/VirtusizeParams.swift
@@ -52,12 +52,12 @@ public class VirtusizeParams {
     /// Gets the script in JavaScript to be called to pass params to the Virtusize web app
     ///
     /// - Returns: A string value of the script in JavaScript
-    func getVsParamsFromSDKScript() -> String {
+	func getVsParamsFromSDKScript() -> String {
         var paramsScript = "vsParamsFromSDK("
         guard let apiKey = Virtusize.APIKey else {
             fatalError("Please set Virtusize.APIKey")
         }
-        guard let storeProductId = Virtusize.product?.externalId else {
+		guard let storeProductId = Virtusize.currentProduct?.externalId else {
             fatalError("The store product ID is invalid")
         }
         paramsScript += "{\(ParamKey.API): '\(apiKey)', "

--- a/Source/UI/VirtusizeButton.swift
+++ b/Source/UI/VirtusizeButton.swift
@@ -78,7 +78,7 @@ public class VirtusizeButton: UIButton, VirtusizeView {
 			isDeallocated = false
 		}
 		VirtusizeRepository.shared.updateCurrentProductBy(
-			viewId: Virtusize.activeVirtusizeViews.first?.memoryAddress
+			vsViewMemoryAddress: Virtusize.activeVirtusizeViews.first?.memoryAddress
 		)
 	}
 

--- a/Source/UI/VirtusizeButton.swift
+++ b/Source/UI/VirtusizeButton.swift
@@ -64,22 +64,9 @@ public class VirtusizeButton: UIButton, VirtusizeView {
     }
 
 	public override func willMove(toWindow: UIWindow?) {
-		// will dismiss a view controller, which is not a VirtusizeWebViewController
-		if toWindow == nil {
-			if !isVirtusizeWebViewControllerOnTopOfScreen() {
-				isDeallocated = true
-				Virtusize.activeVirtusizeViews = Virtusize.virtusizeViews
-					.filter {
-						$0.isDeallocated != true
-					}
-			}
-		// will present an existing view controller
-		} else {
-			isDeallocated = false
+		handleWillMoveWindow(toWindow) { isDeallocated in
+			self.isDeallocated = isDeallocated
 		}
-		VirtusizeRepository.shared.updateCurrentProductBy(
-			vsViewMemoryAddress: Virtusize.activeVirtusizeViews.first?.memoryAddress
-		)
 	}
 
     public func isLoading() {

--- a/Source/UI/VirtusizeButton.swift
+++ b/Source/UI/VirtusizeButton.swift
@@ -44,6 +44,10 @@ public class VirtusizeButton: UIButton, VirtusizeView {
         }
     }
 
+	public var memoryAddress: String {
+		String(format: "%p", self)
+	}
+
     public var presentingViewController: UIViewController?
     public var messageHandler: VirtusizeMessageHandler?
 	public var isDeallocated: Bool?
@@ -60,9 +64,22 @@ public class VirtusizeButton: UIButton, VirtusizeView {
     }
 
 	public override func willMove(toWindow: UIWindow?) {
+		// will dismiss a view controller, which is not a VirtusizeWebViewController
 		if toWindow == nil {
-			isDeallocated = true
+			if !isVirtusizeWebViewControllerOnTopOfScreen() {
+				isDeallocated = true
+				Virtusize.activeVirtusizeViews = Virtusize.virtusizeViews
+					.filter {
+						$0.isDeallocated != true
+					}
+			}
+		// will present an existing view controller
+		} else {
+			isDeallocated = false
 		}
+		VirtusizeRepository.shared.updateCurrentProductBy(
+			viewId: Virtusize.activeVirtusizeViews.first?.memoryAddress
+		)
 	}
 
     public func isLoading() {

--- a/Source/UI/VirtusizeInPageMini.swift
+++ b/Source/UI/VirtusizeInPageMini.swift
@@ -79,7 +79,7 @@ public class VirtusizeInPageMini: VirtusizeInPageView {
 		setLoadingScreen(loading: false)
 		inPageMiniMessageLabel.attributedText = NSAttributedString(
 			string:
-				Virtusize.currentProduct!.getRecommendationText(
+				VirtusizeRepository.shared.currentProduct!.getRecommendationText(
 					VirtusizeRepository.shared.i18nLocalization!,
 					sizeComparisonRecommendedSize,
 					bodyProfileRecommendedSize?.sizeName,

--- a/Source/UI/VirtusizeInPageMini.swift
+++ b/Source/UI/VirtusizeInPageMini.swift
@@ -81,7 +81,7 @@ public class VirtusizeInPageMini: VirtusizeInPageView {
 		setLoadingScreen(loading: false)
 		inPageMiniMessageLabel.attributedText = NSAttributedString(
 			string:
-				VirtusizeRepository.shared.storeProduct!.getRecommendationText(
+				Virtusize.currentProduct!.getRecommendationText(
 					VirtusizeRepository.shared.i18nLocalization!,
 					sizeComparisonRecommendedSize,
 					bodyProfileRecommendedSize?.sizeName,

--- a/Source/UI/VirtusizeInPageMini.swift
+++ b/Source/UI/VirtusizeInPageMini.swift
@@ -76,8 +76,6 @@ public class VirtusizeInPageMini: VirtusizeInPageView {
 		_ sizeComparisonRecommendedSize: SizeComparisonRecommendedSize?,
 		_ bodyProfileRecommendedSize: BodyProfileRecommendedSize?
 	) {
-		super.setInPageRecommendation(sizeComparisonRecommendedSize, bodyProfileRecommendedSize)
-
 		setLoadingScreen(loading: false)
 		inPageMiniMessageLabel.attributedText = NSAttributedString(
 			string:

--- a/Source/UI/VirtusizeInPageStandard.swift
+++ b/Source/UI/VirtusizeInPageStandard.swift
@@ -161,7 +161,7 @@ public class VirtusizeInPageStandard: VirtusizeInPageView {
 
 	private func finishLoading() {
 		setMessageLabelTexts(
-			Virtusize.currentProduct!,
+			VirtusizeRepository.shared.currentProduct!,
 			VirtusizeRepository.shared.i18nLocalization!,
 			sizeComparisonRecommendedSize,
 			bodyProfileRecommendedSize?.sizeName

--- a/Source/UI/VirtusizeInPageStandard.swift
+++ b/Source/UI/VirtusizeInPageStandard.swift
@@ -73,8 +73,6 @@ public class VirtusizeInPageStandard: VirtusizeInPageView {
 
 	private var productImagesAreAnimating: Bool = false
 
-	/// Once the store product image is set, set the value to true to avoid loading repetitively
-	private var storeProductImageIsSet = false
 	private var crossFadeInAnimator: UIViewPropertyAnimator?
 	private var crossFadeOutAnimator: UIViewPropertyAnimator?
 
@@ -120,7 +118,7 @@ public class VirtusizeInPageStandard: VirtusizeInPageView {
 				if $0!.source == .local {
 					self?.userProductImageView.setProductTypeImage(image: $0!.image)
 				}
-				self!.finishSettingProductImages()
+				self!.setProductImages()
 			}
 		}
 
@@ -130,13 +128,12 @@ public class VirtusizeInPageStandard: VirtusizeInPageView {
 				if $0!.source == .local {
 					self?.storeProductImageView.setProductTypeImage(image: $0!.image)
 				}
-				self!.finishSettingProductImages()
+				self!.setProductImages()
 			}
 		}
 	}
 
-	private func finishSettingProductImages() {
-		var imageLoadingSuccessful = false
+	private func setProductImages() {
 		if bestFitUserProduct != nil {
 			if viewModel.storeProductImage.value != nil  && viewModel.userProductImage.value != nil {
 				if inPageStandardView.frame.size.width >= smallInPageWidth {
@@ -145,31 +142,32 @@ public class VirtusizeInPageStandard: VirtusizeInPageView {
 					if !productImagesAreAnimating {
 						// if item to item recommendation is available, we make user and store product images fade in/out repeatedly
 						startCrossFadeProductImageViews()
+						adjustProductImageViewPosition(userProductImageSize: 0, productImageViewOffset: 0)
 					}
 				}
-				imageLoadingSuccessful = true
+				finishLoading()
 			}
 		} else {
 			if viewModel.storeProductImage.value != nil {
-				if inPageStandardView.frame.size.width >= smallInPageWidth {
-					adjustProductImageViewPosition(userProductImageSize: 0, productImageViewOffset: 0)
-				} else {
+				if inPageStandardView.frame.size.width < smallInPageWidth {
 					// if item to item recommendation is not available, stop any fading animations
 					stopCrossFadeProductImageViews()
 				}
-				imageLoadingSuccessful = true
+				adjustProductImageViewPosition(userProductImageSize: 0, productImageViewOffset: 0)
+				finishLoading()
 			}
 		}
-		if imageLoadingSuccessful {
-			setMessageLabelTexts(
-				VirtusizeRepository.shared.storeProduct!,
-				VirtusizeRepository.shared.i18nLocalization!,
-				sizeComparisonRecommendedSize,
-				bodyProfileRecommendedSize?.sizeName
-			)
+	}
 
-			setLoadingScreen(loading: false)
-		}
+	private func finishLoading() {
+		setMessageLabelTexts(
+			VirtusizeRepository.shared.storeProduct!,
+			VirtusizeRepository.shared.i18nLocalization!,
+			sizeComparisonRecommendedSize,
+			bodyProfileRecommendedSize?.sizeName
+		)
+
+		setLoadingScreen(loading: false)
 	}
 
 	private func unbind(to viewModel: VirtusizeInPageStandardViewModel) {
@@ -201,7 +199,7 @@ public class VirtusizeInPageStandard: VirtusizeInPageView {
 		userProductImageView.translatesAutoresizingMaskIntoConstraints = value
 		storeProductImageView.translatesAutoresizingMaskIntoConstraints = value
 		messageStackView.translatesAutoresizingMaskIntoConstraints = value
-		bottomMessageLabel.translatesAutoresizingMaskIntoConstraints = value
+		topMessageLabel.translatesAutoresizingMaskIntoConstraints = value
 		bottomMessageLabel.translatesAutoresizingMaskIntoConstraints = value
 		checkSizeButton.translatesAutoresizingMaskIntoConstraints = value
 		errorImageView.translatesAutoresizingMaskIntoConstraints = value
@@ -235,7 +233,7 @@ public class VirtusizeInPageStandard: VirtusizeInPageView {
 
 		let inPageStandardViewHorizontalConstraints = NSLayoutConstraint.constraints(
 			withVisualFormat: "H:|-0-[inPageStandardView]-0-|",
-			options: NSLayoutConstraint.FormatOptions(rawValue: 0),
+			options: [],
 			metrics: nil,
 			views: views
 		)
@@ -243,7 +241,7 @@ public class VirtusizeInPageStandard: VirtusizeInPageView {
 
 		let inPageStandardViewVerticalConstraints = NSLayoutConstraint.constraints(
 			withVisualFormat: "V:|-0-[inPageStandardView]-10-[virtusizeImageView]-0-|",
-			options: NSLayoutConstraint.FormatOptions(rawValue: 0),
+			options: [],
 			metrics: nil,
 			views: views
 		)
@@ -251,7 +249,7 @@ public class VirtusizeInPageStandard: VirtusizeInPageView {
 
 		let vsIconImageViewHorizontalConstraints = NSLayoutConstraint.constraints(
 			withVisualFormat: "H:|-14-[vsIconImageView]-(>=8)-|",
-			options: NSLayoutConstraint.FormatOptions(rawValue: 0),
+			options: [],
 			metrics: metrics,
 			views: views
 		)
@@ -268,7 +266,7 @@ public class VirtusizeInPageStandard: VirtusizeInPageView {
 
 		let footerHorizontalConstraints = NSLayoutConstraint.constraints(
 				   withVisualFormat: "H:|-0-[virtusizeImageView(>=10)]-(>=0)-[privacyPolicyLink(>=15)]-0-|",
-				   options: NSLayoutConstraint.FormatOptions(rawValue: 0),
+				   options: [],
 				   metrics: nil,
 				   views: views
 		)
@@ -276,7 +274,7 @@ public class VirtusizeInPageStandard: VirtusizeInPageView {
 
 		let leftProductImageViewVerticalConstraints = NSLayoutConstraint.constraints(
 			withVisualFormat: "V:|-(>=14)-[userProductImageView(==40)]-(>=14)-|",
-			options: [.alignAllCenterY],
+			options: [],
 			metrics: nil,
 			views: views
 		)
@@ -284,7 +282,7 @@ public class VirtusizeInPageStandard: VirtusizeInPageView {
 
 		let storeProductImageViewVerticalConstraints = NSLayoutConstraint.constraints(
 			withVisualFormat: "V:|-(>=14)-[storeProductImageView(==40)]-(>=14)-|",
-			options: [.alignAllCenterY],
+			options: [],
 			metrics: nil,
 			views: views
 		)
@@ -292,7 +290,7 @@ public class VirtusizeInPageStandard: VirtusizeInPageView {
 
 		let messageStackViewVerticalConstraints = NSLayoutConstraint.constraints(
 			withVisualFormat: "V:|-(>=14@700)-[messageStackView]-(>=14@700)-|",
-			options: NSLayoutConstraint.FormatOptions(rawValue: 0),
+			options: [],
 			metrics: nil,
 			views: views
 		)
@@ -300,7 +298,7 @@ public class VirtusizeInPageStandard: VirtusizeInPageView {
 
 		let checkSizeButtonVerticalConstraints = NSLayoutConstraint.constraints(
 			withVisualFormat: "V:|-(>=20)-[checkSizeButton]-(>=20)-|",
-			options: NSLayoutConstraint.FormatOptions(rawValue: 0),
+			options: [],
 			metrics: nil,
 			views: views
 		)
@@ -308,7 +306,7 @@ public class VirtusizeInPageStandard: VirtusizeInPageView {
 
         let errorScreenVerticalConstraints = NSLayoutConstraint.constraints(
             withVisualFormat: "V:|-defaultMargin-[errorImageView(40)]-defaultMargin-[errorText]-defaultMargin-|",
-            options: NSLayoutConstraint.FormatOptions(rawValue: 0),
+            options: [.alignAllCenterX],
             metrics: metrics,
             views: views
         )
@@ -316,7 +314,7 @@ public class VirtusizeInPageStandard: VirtusizeInPageView {
 
         let errorImageViewHorizontalConstraints = NSLayoutConstraint.constraints(
             withVisualFormat: "H:|-(>=defaultMargin)-[errorImageView(40)]-(>=defaultMargin)-|",
-            options: NSLayoutConstraint.FormatOptions(rawValue: 0),
+            options: [],
             metrics: metrics,
             views: views
         )
@@ -324,7 +322,7 @@ public class VirtusizeInPageStandard: VirtusizeInPageView {
 
         let errorTextHorizontalConstraints = NSLayoutConstraint.constraints(
             withVisualFormat: "H:|-(>=defaultMargin)-[errorText]-(>=defaultMargin)-|",
-            options: NSLayoutConstraint.FormatOptions(rawValue: 0),
+			options: [.alignAllCenterY],
             metrics: metrics,
             views: views
         )
@@ -338,7 +336,6 @@ public class VirtusizeInPageStandard: VirtusizeInPageView {
 		allConstraints.append(messageStackView.centerYAnchor.constraint(equalTo: inPageStandardView.centerYAnchor))
 		allConstraints.append(checkSizeButton.centerYAnchor.constraint(equalTo: inPageStandardView.centerYAnchor))
 		allConstraints.append(errorImageView.centerXAnchor.constraint(equalTo: inPageStandardView.centerXAnchor))
-		allConstraints.append(errorText.centerXAnchor.constraint(equalTo: inPageStandardView.centerXAnchor))
 
 		NSLayoutConstraint.activate(allConstraints)
     }
@@ -514,13 +511,13 @@ public class VirtusizeInPageStandard: VirtusizeInPageView {
 
 	/// Stops the cross fade animation
 	private func stopCrossFadeProductImageViews() {
-		DispatchQueue.main.async {
+//		DispatchQueue.main.async {
 			self.crossFadeInAnimator?.stopAnimation(true)
 			self.crossFadeOutAnimator?.stopAnimation(true)
 			self.userProductImageView.alpha = 1.0
 			self.storeProductImageView.alpha = 1.0
 			self.productImagesAreAnimating = false
-		}
+//		}
 	}
 
 	private func setMessageLabelTexts(

--- a/Source/UI/VirtusizeInPageStandard.swift
+++ b/Source/UI/VirtusizeInPageStandard.swift
@@ -442,8 +442,6 @@ public class VirtusizeInPageStandard: VirtusizeInPageView {
 		_ sizeComparisonRecommendedSize: SizeComparisonRecommendedSize?,
 		_ bodyProfileRecommendedSize: BodyProfileRecommendedSize?
 	) {
-		super.setInPageRecommendation(sizeComparisonRecommendedSize, bodyProfileRecommendedSize)
-
 		self.sizeComparisonRecommendedSize = sizeComparisonRecommendedSize
 		self.bodyProfileRecommendedSize = bodyProfileRecommendedSize
 

--- a/Source/UI/VirtusizeInPageStandard.swift
+++ b/Source/UI/VirtusizeInPageStandard.swift
@@ -161,7 +161,7 @@ public class VirtusizeInPageStandard: VirtusizeInPageView {
 
 	private func finishLoading() {
 		setMessageLabelTexts(
-			VirtusizeRepository.shared.storeProduct!,
+			Virtusize.currentProduct!,
 			VirtusizeRepository.shared.i18nLocalization!,
 			sizeComparisonRecommendedSize,
 			bodyProfileRecommendedSize?.sizeName

--- a/Source/UI/VirtusizeInPageStandardViewModel.swift
+++ b/Source/UI/VirtusizeInPageStandardViewModel.swift
@@ -27,7 +27,7 @@ internal final class VirtusizeInPageStandardViewModel {
 	let storeProductImage: Observable<VirtusizeProductImage?> = Observable(nil)
 
 	private var currentBestFitUserProduct: VirtusizeInternalProduct?
-	private var currentPdcProduct: VirtusizeProduct?
+	private var currentProductWithPDCData: VirtusizeProduct?
 	private var dispatchQueue = DispatchQueue(label: "com.virtusize.inpage-image-queue")
 
 	func loadUserProductImage(bestFitUserProduct: VirtusizeInternalProduct) {
@@ -59,13 +59,13 @@ internal final class VirtusizeInPageStandardViewModel {
 	}
 
 	func loadStoreProductImage() {
-		guard currentPdcProduct?.externalId != Virtusize.pdcProduct?.externalId ||
+		guard currentProductWithPDCData?.externalId != Virtusize.productWithPDCData?.externalId ||
 			  self.storeProductImage.value == nil
 		else {
 			self.storeProductImage.value = self.storeProductImage.value
 			return
 		}
-		currentPdcProduct = Virtusize.pdcProduct
+		currentProductWithPDCData = Virtusize.productWithPDCData
 		dispatchQueue.async {
 			if let clientProductImage = VirtusizeAPIService.loadImageAsync(url: Virtusize.product?.imageURL).success {
 				self.storeProductImage.value = VirtusizeProductImage(
@@ -73,7 +73,7 @@ internal final class VirtusizeInPageStandardViewModel {
 					source: .client
 				)
 			} else {
-				let cloudinaryImageURL = self.getCloudinaryImageUrl(Virtusize.currentProduct!.cloudinaryPublicId)
+				let cloudinaryImageURL = self.getCloudinaryImageUrl(VirtusizeRepository.shared.currentProduct!.cloudinaryPublicId)
 				if let storeProductImage = VirtusizeAPIService.loadImageAsync(url: cloudinaryImageURL).success {
 					self.storeProductImage.value = VirtusizeProductImage(
 						image: storeProductImage,
@@ -81,8 +81,8 @@ internal final class VirtusizeInPageStandardViewModel {
 					)
 				} else {
 					let productTypeImage = self.getProductTypeImage(
-						productType: Virtusize.currentProduct!.productType,
-						style: Virtusize.currentProduct!.storeProductMeta?.additionalInfo?.style
+						productType: VirtusizeRepository.shared.currentProduct!.productType,
+						style: VirtusizeRepository.shared.currentProduct!.storeProductMeta?.additionalInfo?.style
 					)
 					self.storeProductImage.value = VirtusizeProductImage(
 						image: productTypeImage,

--- a/Source/UI/VirtusizeInPageStandardViewModel.swift
+++ b/Source/UI/VirtusizeInPageStandardViewModel.swift
@@ -27,7 +27,7 @@ internal final class VirtusizeInPageStandardViewModel {
 	let storeProductImage: Observable<VirtusizeProductImage?> = Observable(nil)
 
 	private var currentBestFitUserProduct: VirtusizeInternalProduct?
-	private var currentStoreProduct: VirtusizeProduct?
+	private var currentPdcProduct: VirtusizeProduct?
 	private var dispatchQueue = DispatchQueue(label: "com.virtusize.inpage-image-queue")
 
 	func loadUserProductImage(bestFitUserProduct: VirtusizeInternalProduct) {
@@ -59,13 +59,13 @@ internal final class VirtusizeInPageStandardViewModel {
 	}
 
 	func loadStoreProductImage() {
-		guard currentStoreProduct?.externalId != Virtusize.internalProduct?.externalId ||
+		guard currentPdcProduct?.externalId != Virtusize.pdcProduct?.externalId ||
 			  self.storeProductImage.value == nil
 		else {
 			self.storeProductImage.value = self.storeProductImage.value
 			return
 		}
-		currentStoreProduct = Virtusize.internalProduct
+		currentPdcProduct = Virtusize.pdcProduct
 		dispatchQueue.async {
 			if let clientProductImage = VirtusizeAPIService.loadImageAsync(url: Virtusize.product?.imageURL).success {
 				self.storeProductImage.value = VirtusizeProductImage(
@@ -73,7 +73,7 @@ internal final class VirtusizeInPageStandardViewModel {
 					source: .client
 				)
 			} else {
-				let cloudinaryImageURL = self.getCloudinaryImageUrl(VirtusizeRepository.shared.storeProduct!.cloudinaryPublicId)
+				let cloudinaryImageURL = self.getCloudinaryImageUrl(Virtusize.currentProduct!.cloudinaryPublicId)
 				if let storeProductImage = VirtusizeAPIService.loadImageAsync(url: cloudinaryImageURL).success {
 					self.storeProductImage.value = VirtusizeProductImage(
 						image: storeProductImage,
@@ -81,8 +81,8 @@ internal final class VirtusizeInPageStandardViewModel {
 					)
 				} else {
 					let productTypeImage = self.getProductTypeImage(
-						productType: VirtusizeRepository.shared.storeProduct!.productType,
-						style: VirtusizeRepository.shared.storeProduct!.storeProductMeta?.additionalInfo?.style
+						productType: Virtusize.currentProduct!.productType,
+						style: Virtusize.currentProduct!.storeProductMeta?.additionalInfo?.style
 					)
 					self.storeProductImage.value = VirtusizeProductImage(
 						image: productTypeImage,

--- a/Source/UI/VirtusizeInPageStandardViewModel.swift
+++ b/Source/UI/VirtusizeInPageStandardViewModel.swift
@@ -28,6 +28,7 @@ internal final class VirtusizeInPageStandardViewModel {
 
 	private var currentBestFitUserProduct: VirtusizeInternalProduct?
 	private var currentStoreProduct: VirtusizeProduct?
+	private var dispatchQueue = DispatchQueue(label: "com.virtusize.inpage-image-queue")
 
 	func loadUserProductImage(bestFitUserProduct: VirtusizeInternalProduct) {
 		if currentBestFitUserProduct != nil && currentBestFitUserProduct!.id == bestFitUserProduct.id {
@@ -35,7 +36,7 @@ internal final class VirtusizeInPageStandardViewModel {
 			return
 		}
 		currentBestFitUserProduct = bestFitUserProduct
-		DispatchQueue.global().async {
+		dispatchQueue.async {
 			self.userProductImage.value = nil
 			let cloudinaryImageURL = self.getCloudinaryImageUrl(bestFitUserProduct.cloudinaryPublicId)
 			let loadImageResponse = VirtusizeAPIService.loadImageAsync(url: cloudinaryImageURL)
@@ -65,7 +66,7 @@ internal final class VirtusizeInPageStandardViewModel {
 			return
 		}
 		currentStoreProduct = Virtusize.internalProduct
-		DispatchQueue.global().async {
+		dispatchQueue.async {
 			if let clientProductImage = VirtusizeAPIService.loadImageAsync(url: Virtusize.product?.imageURL).success {
 				self.storeProductImage.value = VirtusizeProductImage(
 					image: clientProductImage,

--- a/Source/UI/VirtusizeInPageStandardViewModel.swift
+++ b/Source/UI/VirtusizeInPageStandardViewModel.swift
@@ -28,7 +28,7 @@ internal final class VirtusizeInPageStandardViewModel {
 
 	private var currentBestFitUserProduct: VirtusizeInternalProduct?
 	private var currentProductWithPDCData: VirtusizeProduct?
-	private var dispatchQueue = DispatchQueue(label: "com.virtusize.inpage-image-queue")
+	private let dispatchQueue = DispatchQueue(label: "com.virtusize.inpage-image-queue")
 
 	func loadUserProductImage(bestFitUserProduct: VirtusizeInternalProduct) {
 		if currentBestFitUserProduct != nil && currentBestFitUserProduct!.id == bestFitUserProduct.id {

--- a/Source/UI/VirtusizeInPageView.swift
+++ b/Source/UI/VirtusizeInPageView.swift
@@ -32,6 +32,9 @@ public class VirtusizeInPageView: UIView, VirtusizeView {
         }
     }
 
+	public var memoryAddress: String {
+		String(format: "%p", self)
+	}
     public var presentingViewController: UIViewController?
     public var messageHandler: VirtusizeMessageHandler?
 	public var isDeallocated: Bool?
@@ -55,9 +58,22 @@ public class VirtusizeInPageView: UIView, VirtusizeView {
     }
 
 	public override func willMove(toWindow: UIWindow?) {
+		// will dismiss a view controller, which is not a VirtusizeWebViewController
 		if toWindow == nil {
-			isDeallocated = true
+			if !isVirtusizeWebViewControllerOnTopOfScreen() {
+				isDeallocated = true
+				Virtusize.activeVirtusizeViews = Virtusize.virtusizeViews
+					.filter {
+						$0.isDeallocated != true
+					}
+			}
+		// will present an existing view controller
+		} else {
+			isDeallocated = false
 		}
+		VirtusizeRepository.shared.updateCurrentProductBy(
+			viewId: Virtusize.activeVirtusizeViews.first?.memoryAddress
+		)
 	}
 
     public func isLoading() {
@@ -185,5 +201,4 @@ extension VirtusizeInPageView: VirtusizeEventHandler {
 			VirtusizeRepository.shared.switchInPageRecommendation()
 		}
 	}
-
 }

--- a/Source/UI/VirtusizeInPageView.swift
+++ b/Source/UI/VirtusizeInPageView.swift
@@ -137,7 +137,7 @@ extension VirtusizeInPageView: VirtusizeEventHandler {
 	}
 
 	public func userSelectedProduct(userProductId: Int?) {
-		DispatchQueue.global().async {
+		Virtusize.dispatchQueue.async {
 			VirtusizeRepository.shared.fetchDataForInPageRecommendation(
 				shouldUpdateUserProducts: false,
 				selectedUserProductId: userProductId
@@ -147,7 +147,7 @@ extension VirtusizeInPageView: VirtusizeEventHandler {
 	}
 
 	public func userAddedProduct(userProductId: Int?) {
-		DispatchQueue.global().async {
+		Virtusize.dispatchQueue.async {
 			VirtusizeRepository.shared.fetchDataForInPageRecommendation(
 				shouldUpdateUserProducts: true,
 				selectedUserProductId: userProductId
@@ -157,20 +157,20 @@ extension VirtusizeInPageView: VirtusizeEventHandler {
 	}
 
 	public func userChangedRecommendationType(changedType: SizeRecommendationType?) {
-		DispatchQueue.global().async {
+		Virtusize.dispatchQueue.async {
 			VirtusizeRepository.shared.switchInPageRecommendation(changedType)
 		}
 	}
 
 	public func userUpdatedBodyMeasurements(recommendedSize: String?) {
-		DispatchQueue.global().async {
+		Virtusize.dispatchQueue.async {
 			VirtusizeRepository.shared.updateUserBodyRecommendedSize(recommendedSize)
 			VirtusizeRepository.shared.switchInPageRecommendation(.body)
 		}
 	}
 
 	public func userLoggedIn() {
-		DispatchQueue.global().async {
+		Virtusize.dispatchQueue.async {
 			VirtusizeRepository.shared.updateUserSession()
 			VirtusizeRepository.shared.fetchDataForInPageRecommendation()
 			VirtusizeRepository.shared.switchInPageRecommendation()
@@ -178,7 +178,7 @@ extension VirtusizeInPageView: VirtusizeEventHandler {
 	}
 
 	public func clearUserData() {
-		DispatchQueue.global().async {
+		Virtusize.dispatchQueue.async {
 			VirtusizeRepository.shared.clearUserData()
 			VirtusizeRepository.shared.updateUserSession()
 			VirtusizeRepository.shared.fetchDataForInPageRecommendation(shouldUpdateUserProducts: false)

--- a/Source/UI/VirtusizeInPageView.swift
+++ b/Source/UI/VirtusizeInPageView.swift
@@ -140,6 +140,10 @@ public class VirtusizeInPageView: UIView, VirtusizeView {
 		self.loadingTextTimer?.invalidate()
 		self.loadingTextTimer = nil
     }
+
+	private func getAssociatedProduct() -> VirtusizeInternalProduct? {
+		return Virtusize.virtusizeViewToProductDict[memoryAddress]
+	}
 }
 
 extension VirtusizeInPageView: VirtusizeEventHandler {
@@ -158,7 +162,7 @@ extension VirtusizeInPageView: VirtusizeEventHandler {
 				shouldUpdateUserProducts: false,
 				selectedUserProductId: userProductId
 			)
-			VirtusizeRepository.shared.switchInPageRecommendation(.compareProduct)
+			VirtusizeRepository.shared.switchInPageRecommendation(product: self.getAssociatedProduct(), .compareProduct)
 		}
 	}
 
@@ -168,20 +172,20 @@ extension VirtusizeInPageView: VirtusizeEventHandler {
 				shouldUpdateUserProducts: true,
 				selectedUserProductId: userProductId
 			)
-			VirtusizeRepository.shared.switchInPageRecommendation(.compareProduct)
+			VirtusizeRepository.shared.switchInPageRecommendation(product: self.getAssociatedProduct(), .compareProduct)
 		}
 	}
 
 	public func userChangedRecommendationType(changedType: SizeRecommendationType?) {
 		Virtusize.dispatchQueue.async {
-			VirtusizeRepository.shared.switchInPageRecommendation(changedType)
+			VirtusizeRepository.shared.switchInPageRecommendation(product: self.getAssociatedProduct(), changedType)
 		}
 	}
 
 	public func userUpdatedBodyMeasurements(recommendedSize: String?) {
 		Virtusize.dispatchQueue.async {
 			VirtusizeRepository.shared.updateUserBodyRecommendedSize(recommendedSize)
-			VirtusizeRepository.shared.switchInPageRecommendation(.body)
+			VirtusizeRepository.shared.switchInPageRecommendation(product: self.getAssociatedProduct(), .body)
 		}
 	}
 
@@ -189,7 +193,7 @@ extension VirtusizeInPageView: VirtusizeEventHandler {
 		Virtusize.dispatchQueue.async {
 			VirtusizeRepository.shared.updateUserSession()
 			VirtusizeRepository.shared.fetchDataForInPageRecommendation()
-			VirtusizeRepository.shared.switchInPageRecommendation()
+			VirtusizeRepository.shared.switchInPageRecommendation(product: self.getAssociatedProduct())
 		}
 	}
 
@@ -198,7 +202,7 @@ extension VirtusizeInPageView: VirtusizeEventHandler {
 			VirtusizeRepository.shared.clearUserData()
 			VirtusizeRepository.shared.updateUserSession()
 			VirtusizeRepository.shared.fetchDataForInPageRecommendation(shouldUpdateUserProducts: false)
-			VirtusizeRepository.shared.switchInPageRecommendation()
+			VirtusizeRepository.shared.switchInPageRecommendation(product: self.getAssociatedProduct())
 		}
 	}
 }

--- a/Source/UI/VirtusizeInPageView.swift
+++ b/Source/UI/VirtusizeInPageView.swift
@@ -58,22 +58,9 @@ public class VirtusizeInPageView: UIView, VirtusizeView {
     }
 
 	public override func willMove(toWindow: UIWindow?) {
-		// will dismiss a view controller, which is not a VirtusizeWebViewController
-		if toWindow == nil {
-			if !isVirtusizeWebViewControllerOnTopOfScreen() {
-				isDeallocated = true
-				Virtusize.activeVirtusizeViews = Virtusize.virtusizeViews
-					.filter {
-						$0.isDeallocated != true
-					}
-			}
-		// will present an existing view controller
-		} else {
-			isDeallocated = false
+		handleWillMoveWindow(toWindow) { isDeallocated in
+			self.isDeallocated = isDeallocated
 		}
-		VirtusizeRepository.shared.updateCurrentProductBy(
-			vsViewMemoryAddress: Virtusize.activeVirtusizeViews.first?.memoryAddress
-		)
 	}
 
     public func isLoading() {
@@ -157,7 +144,7 @@ extension VirtusizeInPageView: VirtusizeEventHandler {
 	}
 
 	public func userSelectedProduct(userProductId: Int?) {
-		DispatchQueue.global().async {
+		Virtusize.dispatchQueue.async {
 			VirtusizeRepository.shared.fetchDataForInPageRecommendation(
 				shouldUpdateUserProducts: false,
 				selectedUserProductId: userProductId
@@ -167,7 +154,7 @@ extension VirtusizeInPageView: VirtusizeEventHandler {
 	}
 
 	public func userAddedProduct(userProductId: Int?) {
-		DispatchQueue.global().async {
+		Virtusize.dispatchQueue.async {
 			VirtusizeRepository.shared.fetchDataForInPageRecommendation(
 				shouldUpdateUserProducts: true,
 				selectedUserProductId: userProductId
@@ -177,20 +164,20 @@ extension VirtusizeInPageView: VirtusizeEventHandler {
 	}
 
 	public func userChangedRecommendationType(changedType: SizeRecommendationType?) {
-		DispatchQueue.global().async {
+		Virtusize.dispatchQueue.async {
 			VirtusizeRepository.shared.switchInPageRecommendation(product: self.getAssociatedProduct(), changedType)
 		}
 	}
 
 	public func userUpdatedBodyMeasurements(recommendedSize: String?) {
-		DispatchQueue.global().async {
+		Virtusize.dispatchQueue.async {
 			VirtusizeRepository.shared.updateUserBodyRecommendedSize(recommendedSize)
 			VirtusizeRepository.shared.switchInPageRecommendation(product: self.getAssociatedProduct(), .body)
 		}
 	}
 
 	public func userLoggedIn() {
-		DispatchQueue.global().async {
+		Virtusize.dispatchQueue.async {
 			VirtusizeRepository.shared.updateUserSession()
 			VirtusizeRepository.shared.fetchDataForInPageRecommendation()
 			VirtusizeRepository.shared.switchInPageRecommendation(product: self.getAssociatedProduct())
@@ -198,7 +185,7 @@ extension VirtusizeInPageView: VirtusizeEventHandler {
 	}
 
 	public func clearUserData() {
-		DispatchQueue.global().async {
+		Virtusize.dispatchQueue.async {
 			VirtusizeRepository.shared.clearUserData()
 			VirtusizeRepository.shared.updateUserSession()
 			VirtusizeRepository.shared.fetchDataForInPageRecommendation(shouldUpdateUserProducts: false)

--- a/Source/UI/VirtusizeInPageView.swift
+++ b/Source/UI/VirtusizeInPageView.swift
@@ -72,7 +72,7 @@ public class VirtusizeInPageView: UIView, VirtusizeView {
 			isDeallocated = false
 		}
 		VirtusizeRepository.shared.updateCurrentProductBy(
-			viewId: Virtusize.activeVirtusizeViews.first?.memoryAddress
+			vsViewMemoryAddress: Virtusize.activeVirtusizeViews.first?.memoryAddress
 		)
 	}
 
@@ -142,7 +142,7 @@ public class VirtusizeInPageView: UIView, VirtusizeView {
     }
 
 	private func getAssociatedProduct() -> VirtusizeInternalProduct? {
-		return Virtusize.virtusizeViewToProductDict[memoryAddress]
+		return VirtusizeRepository.shared.availableVSViewToProductDict[memoryAddress]
 	}
 }
 
@@ -157,7 +157,7 @@ extension VirtusizeInPageView: VirtusizeEventHandler {
 	}
 
 	public func userSelectedProduct(userProductId: Int?) {
-		Virtusize.dispatchQueue.async {
+		DispatchQueue.global().async {
 			VirtusizeRepository.shared.fetchDataForInPageRecommendation(
 				shouldUpdateUserProducts: false,
 				selectedUserProductId: userProductId
@@ -167,7 +167,7 @@ extension VirtusizeInPageView: VirtusizeEventHandler {
 	}
 
 	public func userAddedProduct(userProductId: Int?) {
-		Virtusize.dispatchQueue.async {
+		DispatchQueue.global().async {
 			VirtusizeRepository.shared.fetchDataForInPageRecommendation(
 				shouldUpdateUserProducts: true,
 				selectedUserProductId: userProductId
@@ -177,20 +177,20 @@ extension VirtusizeInPageView: VirtusizeEventHandler {
 	}
 
 	public func userChangedRecommendationType(changedType: SizeRecommendationType?) {
-		Virtusize.dispatchQueue.async {
+		DispatchQueue.global().async {
 			VirtusizeRepository.shared.switchInPageRecommendation(product: self.getAssociatedProduct(), changedType)
 		}
 	}
 
 	public func userUpdatedBodyMeasurements(recommendedSize: String?) {
-		Virtusize.dispatchQueue.async {
+		DispatchQueue.global().async {
 			VirtusizeRepository.shared.updateUserBodyRecommendedSize(recommendedSize)
 			VirtusizeRepository.shared.switchInPageRecommendation(product: self.getAssociatedProduct(), .body)
 		}
 	}
 
 	public func userLoggedIn() {
-		Virtusize.dispatchQueue.async {
+		DispatchQueue.global().async {
 			VirtusizeRepository.shared.updateUserSession()
 			VirtusizeRepository.shared.fetchDataForInPageRecommendation()
 			VirtusizeRepository.shared.switchInPageRecommendation(product: self.getAssociatedProduct())
@@ -198,7 +198,7 @@ extension VirtusizeInPageView: VirtusizeEventHandler {
 	}
 
 	public func clearUserData() {
-		Virtusize.dispatchQueue.async {
+		DispatchQueue.global().async {
 			VirtusizeRepository.shared.clearUserData()
 			VirtusizeRepository.shared.updateUserSession()
 			VirtusizeRepository.shared.fetchDataForInPageRecommendation(shouldUpdateUserProducts: false)

--- a/Source/UI/VirtusizeView.swift
+++ b/Source/UI/VirtusizeView.swift
@@ -29,6 +29,7 @@ public protocol VirtusizeView {
     var style: VirtusizeViewStyle { get }
     var presentingViewController: UIViewController? { get set }
     var messageHandler: VirtusizeMessageHandler? { get set }
+	var memoryAddress: String { get }
 	var isDeallocated: Bool? { get set }
 
 	/// Sets up the loading UI
@@ -48,4 +49,20 @@ extension VirtusizeView {
             presentingViewController?.present(virtusize, animated: true, completion: nil)
         }
     }
+
+	internal func getTopViewController(base: UIViewController?) -> UIViewController? {
+		if let nav = base as? UINavigationController {
+			return getTopViewController(base: nav.visibleViewController)
+		} else if let tab = base as? UITabBarController, let selected = tab.selectedViewController {
+			return getTopViewController(base: selected)
+
+		} else if let presented = base?.presentedViewController {
+			return getTopViewController(base: presented)
+		}
+		return base
+	}
+
+	internal func isVirtusizeWebViewControllerOnTopOfScreen() -> Bool {
+		return getTopViewController(base: self.presentingViewController) is VirtusizeWebViewController == true
+	}
 }

--- a/Source/UI/VirtusizeWebViewController.swift
+++ b/Source/UI/VirtusizeWebViewController.swift
@@ -34,6 +34,7 @@ public protocol VirtusizeMessageHandler: class {
 
 /// This `UIViewController` represents the Virtusize Window
 public final class VirtusizeWebViewController: UIViewController {
+	private var product: VirtusizeProduct?
     public weak var messageHandler: VirtusizeMessageHandler?
 	internal var eventHandler: VirtusizeEventHandler?
 

--- a/Source/UI/VirtusizeWebViewController.swift
+++ b/Source/UI/VirtusizeWebViewController.swift
@@ -27,7 +27,7 @@ import WebKit
 
 /// The methods of this protocol notify you with Virtusize specific messages such as errors as
 /// `VirtusizeError` and events as `VirtusizeEvent` and tell you when to dismiss the view controller
-public protocol VirtusizeMessageHandler: class {
+public protocol VirtusizeMessageHandler: AnyObject {
     func virtusizeController(_ controller: VirtusizeWebViewController, didReceiveError error: VirtusizeError)
     func virtusizeController(_ controller: VirtusizeWebViewController, didReceiveEvent event: VirtusizeEvent)
 }

--- a/Source/Virtusize.swift
+++ b/Source/Virtusize.swift
@@ -57,6 +57,8 @@ public class Virtusize {
 	/// The singleton instance of `VirtusizeRepository`
 	private static var virtusizeRepository = VirtusizeRepository.shared
 
+	internal static var dispatchQueue = DispatchQueue(label: "com.virtusize.default-queue")
+
 	/// The internal property for product
 	internal static var internalProduct: VirtusizeProduct?
 	/// The Virtusize product to get the value from the`productDataCheck` request
@@ -68,7 +70,7 @@ public class Virtusize {
 
 			internalProduct = newValue
 
-			DispatchQueue.global().async {
+			dispatchQueue.async {
 				guard VirtusizeRepository.shared.isProductValid(product: newValue) else {
 					DispatchQueue.main.async {
 						for index in 0...virtusizeViews.count-1 {

--- a/Source/Virtusize.swift
+++ b/Source/Virtusize.swift
@@ -74,7 +74,7 @@ public class Virtusize {
 			productWithPDCData = newValue
 
 			dispatchQueue.async {
-				guard VirtusizeRepository.shared.isProductValid(product: newValue) else {
+				guard virtusizeRepository.isProductValid(product: newValue) else {
 					DispatchQueue.main.async {
 						for virtusizeView in activeVirtusizeViews {
 							(virtusizeView as? UIView)?.isHidden = true
@@ -150,7 +150,7 @@ public class Virtusize {
 
     /// Sets up the VirtusizeView and adds it to `virtusizeViews`
     public class func setVirtusizeView(_ any: Any, _ view: VirtusizeView) {
-		VirtusizeRepository.shared.cleanVirtusizeViewToProductDict(virtusizeViews: virtusizeViews)
+		virtusizeRepository.cleanAvailableVSViewToProductDict()
 		virtusizeViews = virtusizeViews.filter { $0.isDeallocated != true }
 
         var mutableView = view

--- a/Source/Virtusize.swift
+++ b/Source/Virtusize.swift
@@ -52,15 +52,24 @@ public class Virtusize {
     public static var productDataCheckDidSucceed = Notification.Name("VirtusizeProductDataCheckDidSucceed")
 
 	/// The array of `VirtusizeView` that clients use on their mobile application
-	private static var virtusizeViews: [VirtusizeView] = []
+	internal static var virtusizeViews: [VirtusizeView] = []
+
+	/// The array of `VirtusizeView` that is active on the screen of the mobile application
+	internal static var activeVirtusizeViews: [VirtusizeView] = []
 
 	/// The singleton instance of `VirtusizeRepository`
 	private static var virtusizeRepository = VirtusizeRepository.shared
 
 	internal static var dispatchQueue = DispatchQueue(label: "com.virtusize.default-queue")
+	
+	// TODO
+	internal static var stackProducts: [VirtusizeInternalProduct] = []
+
+	// This variable holds the data of the current store product from the Virtusize API
+	internal static var currentProduct: VirtusizeInternalProduct?
 
 	/// The internal property for product
-	internal static var internalProduct: VirtusizeProduct?
+	internal static var pdcProduct: VirtusizeProduct?
 	/// The Virtusize product to get the value from the`productDataCheck` request
 	public static var product: VirtusizeProduct? {
 		set {
@@ -68,26 +77,26 @@ public class Virtusize {
 				return
 			}
 
-			internalProduct = newValue
+			pdcProduct = newValue
 
 			dispatchQueue.async {
 				guard VirtusizeRepository.shared.isProductValid(product: newValue) else {
 					DispatchQueue.main.async {
-						for index in 0...virtusizeViews.count-1 {
-							(virtusizeViews[index] as? UIView)?.isHidden = true
+						for virtusizeView in activeVirtusizeViews {
+							(virtusizeView as? UIView)?.isHidden = true
 						}
 					}
 					return
 				}
 
 				DispatchQueue.main.async {
-					for index in 0...virtusizeViews.count-1 {
-						(virtusizeViews[index] as? VirtusizeInPageView)?.setup()
-						virtusizeViews[index].isLoading()
+					for virtusizeView in activeVirtusizeViews {
+						(virtusizeView as? VirtusizeInPageView)?.setup()
+						virtusizeView.isLoading()
 					}
 				}
 
-				if virtusizeRepository.fetchInitialData(productId: internalProduct!.productCheckData!.productDataId) {
+				if virtusizeRepository.fetchInitialData(productId: pdcProduct!.productCheckData!.productDataId) {
 					virtusizeRepository.updateUserSession()
 					virtusizeRepository.fetchDataForInPageRecommendation()
 					virtusizeRepository.switchInPageRecommendation()
@@ -95,7 +104,7 @@ public class Virtusize {
 			}
 		}
 		get {
-			return internalProduct
+			return pdcProduct
 		}
 	}
 
@@ -106,8 +115,8 @@ public class Virtusize {
 		set {
 			if newValue?.0 != nil || newValue?.1 != nil {
 				DispatchQueue.main.async {
-					for index in 0...virtusizeViews.count-1 {
-						(virtusizeViews[index] as? VirtusizeInPageView)?.setInPageRecommendation(newValue?.0, newValue?.1)
+					for virtusizeView in activeVirtusizeViews {
+						(virtusizeView as? VirtusizeInPageView)?.setInPageRecommendation(newValue?.0, newValue?.1)
 					}
 					self.updateInPageViews = (nil, nil)
 				}
@@ -125,8 +134,8 @@ public class Virtusize {
 		set {
 			if newValue == true {
 				DispatchQueue.main.async {
-					for index in 0...virtusizeViews.count-1 {
-						(virtusizeViews[index] as? VirtusizeInPageView)?.showErrorScreen()
+					for virtusizeView in activeVirtusizeViews {
+						(virtusizeView as? VirtusizeInPageView)?.showErrorScreen()
 					}
 					self.showInPageError = false
 				}
@@ -141,12 +150,15 @@ public class Virtusize {
 
     /// Sets up the VirtusizeView and adds it to `virtusizeViews`
     public class func setVirtusizeView(_ any: Any, _ view: VirtusizeView) {
+		VirtusizeRepository.shared.cleanVirtusizeViewToProductDict(virtusizeViews: virtusizeViews)
 		virtusizeViews = virtusizeViews.filter { $0.isDeallocated != true }
+
         var mutableView = view
         mutableView.messageHandler = any as? VirtusizeMessageHandler
         mutableView.presentingViewController = any as? UIViewController
 		(mutableView as? UIView)?.didMoveToWindow()
         virtusizeViews.append(mutableView)
+		activeVirtusizeViews = virtusizeViews.filter { $0.presentingViewController == any as? UIViewController }
     }
 
     /// The API request for sending an order to the server

--- a/Source/Virtusize.swift
+++ b/Source/Virtusize.swift
@@ -85,10 +85,11 @@ public class Virtusize {
 					}
 				}
 
-				virtusizeRepository.fetchInitialData(productId: internalProduct!.productCheckData!.productDataId)
-				virtusizeRepository.updateUserSession()
-				virtusizeRepository.fetchDataForInPageRecommendation()
-				virtusizeRepository.switchInPageRecommendation()
+				if virtusizeRepository.fetchInitialData(productId: internalProduct!.productCheckData!.productDataId) {
+					virtusizeRepository.updateUserSession()
+					virtusizeRepository.fetchDataForInPageRecommendation()
+					virtusizeRepository.switchInPageRecommendation()
+				}
 			}
 		}
 		get {

--- a/Source/Virtusize.swift
+++ b/Source/Virtusize.swift
@@ -108,15 +108,25 @@ public class Virtusize {
 		}
 	}
 
+	typealias ProductRecommendationData = (
+		VirtusizeInternalProduct?,
+		SizeComparisonRecommendedSize?,
+		BodyProfileRecommendedSize?
+	)
+
 	/// The private property for updating InPage views
-	private static var _updateInPageViews: (VirtusizeInternalProduct?, SizeComparisonRecommendedSize?, BodyProfileRecommendedSize?)?
+	private static var _updateInPageViews: ProductRecommendationData?
 	/// The property to be set to update InPage views.
-	internal static var updateInPageViews: (VirtusizeInternalProduct?, SizeComparisonRecommendedSize?, BodyProfileRecommendedSize?)? {
+	internal static var updateInPageViews: ProductRecommendationData? {
 		set {
 			if newValue?.1 != nil || newValue?.2 != nil {
 				DispatchQueue.main.async {
-					let filteredViewMemoryAddress = virtusizeViewToProductDict.filter { $0.value.externalId == newValue?.0?.externalId }.map { $0.key }
-					for virtusizeView in virtusizeViews.filter { filteredViewMemoryAddress.contains($0.memoryAddress) } {
+					let filteredViewMemoryAddress = virtusizeViewToProductDict
+						.filter { $0.value.externalId == newValue?.0?.externalId }
+						.map { $0.key }
+					let filteredVirtusizeViews = virtusizeViews
+						.filter { filteredViewMemoryAddress.contains($0.memoryAddress) }
+					for virtusizeView in filteredVirtusizeViews {
 						(virtusizeView as? VirtusizeInPageView)?.setInPageRecommendation(newValue?.1, newValue?.2
 						)
 					}

--- a/Source/VirtusizeRepository.swift
+++ b/Source/VirtusizeRepository.swift
@@ -147,7 +147,8 @@ internal class VirtusizeRepository: NSObject {
 
 	internal func cleanVirtusizeViewToProductDict(virtusizeViews: [VirtusizeView]) {
 		let deallocatedMemoryAddresses = virtusizeViews.filter { $0.isDeallocated == true }.map { $0.memoryAddress }
-		Virtusize.virtusizeViewToProductDict = Virtusize.virtusizeViewToProductDict.filter { !deallocatedMemoryAddresses.contains($0.key) }
+		Virtusize.virtusizeViewToProductDict = Virtusize.virtusizeViewToProductDict
+			.filter { !deallocatedMemoryAddresses.contains($0.key) }
 	}
 
 	/// Fetches data for InPage recommendation
@@ -242,7 +243,10 @@ internal class VirtusizeRepository: NSObject {
 	/// Switch the recommendation for InPage based on the recommendation type
 	///
 	/// - Parameter selectedRecommendedType the selected recommendation compare view type
-	internal func switchInPageRecommendation(product: VirtusizeInternalProduct?, _ selectedRecommendedType: SizeRecommendationType? = nil) {
+	internal func switchInPageRecommendation(
+		product: VirtusizeInternalProduct?,
+		_ selectedRecommendedType: SizeRecommendationType? = nil
+	) {
 		switch selectedRecommendedType {
 		case .compareProduct:
 			Virtusize.updateInPageViews = (product, sizeComparisonRecommendedSize, nil)

--- a/Source/VirtusizeRepository.swift
+++ b/Source/VirtusizeRepository.swift
@@ -37,8 +37,6 @@ internal class VirtusizeRepository: NSObject {
 
 	/// The array of `VirtusizeView` that clients use on their mobile application
 	var productTypes: [VirtusizeProductType]?
-	// This dictionary holds the information of which the memory address of a view points to which store product object
-	var virtusizeViewToProductDict: [String: VirtusizeInternalProduct] = [:]
 	// This variable holds the i18n localization texts
 	var i18nLocalization: VirtusizeI18nLocalization?
 
@@ -114,9 +112,9 @@ internal class VirtusizeRepository: NSObject {
 		}
 
 		Virtusize.currentProduct = VirtusizeAPIService.getStoreProductInfoAsync(productId: productId).success
-		
+
 		for view in Virtusize.activeVirtusizeViews {
-			virtusizeViewToProductDict[view.memoryAddress] = Virtusize.currentProduct
+			Virtusize.virtusizeViewToProductDict[view.memoryAddress] = Virtusize.currentProduct
 		}
 
 		if Virtusize.currentProduct == nil {
@@ -142,14 +140,14 @@ internal class VirtusizeRepository: NSObject {
 		guard let viewId = viewId else {
 			return
 		}
-		if let storeProduct = virtusizeViewToProductDict[viewId] {
+		if let storeProduct = Virtusize.virtusizeViewToProductDict[viewId] {
 			Virtusize.currentProduct = storeProduct
 		}
 	}
 
 	internal func cleanVirtusizeViewToProductDict(virtusizeViews: [VirtusizeView]) {
 		let deallocatedMemoryAddresses = virtusizeViews.filter { $0.isDeallocated == true }.map { $0.memoryAddress }
-		virtusizeViewToProductDict = virtusizeViewToProductDict.filter { !deallocatedMemoryAddresses.contains($0.key) }
+		Virtusize.virtusizeViewToProductDict = Virtusize.virtusizeViewToProductDict.filter { !deallocatedMemoryAddresses.contains($0.key) }
 	}
 
 	/// Fetches data for InPage recommendation
@@ -244,14 +242,14 @@ internal class VirtusizeRepository: NSObject {
 	/// Switch the recommendation for InPage based on the recommendation type
 	///
 	/// - Parameter selectedRecommendedType the selected recommendation compare view type
-	internal func switchInPageRecommendation(_ selectedRecommendedType: SizeRecommendationType? = nil) {
+	internal func switchInPageRecommendation(product: VirtusizeInternalProduct?, _ selectedRecommendedType: SizeRecommendationType? = nil) {
 		switch selectedRecommendedType {
 		case .compareProduct:
-			Virtusize.updateInPageViews = (sizeComparisonRecommendedSize, nil)
+			Virtusize.updateInPageViews = (product, sizeComparisonRecommendedSize, nil)
 		case .body:
-			Virtusize.updateInPageViews = (nil, bodyProfileRecommendedSize)
+			Virtusize.updateInPageViews = (product, nil, bodyProfileRecommendedSize)
 		default:
-			Virtusize.updateInPageViews = (sizeComparisonRecommendedSize, bodyProfileRecommendedSize)
+			Virtusize.updateInPageViews = (product, sizeComparisonRecommendedSize, bodyProfileRecommendedSize)
 		}
 	}
 

--- a/Source/VirtusizeRepository.swift
+++ b/Source/VirtusizeRepository.swift
@@ -107,27 +107,30 @@ internal class VirtusizeRepository: NSObject {
 	/// Fetches the initial data such as store product info, product type lists and i18 localization
 	///
 	/// - Parameter productId: the product ID provided by the client
-	internal func fetchInitialData(productId: Int?) {
+	/// - Returns: true if the initial data are fetched
+	internal func fetchInitialData(productId: Int?) -> Bool {
 		guard let productId = productId else {
-			return
+			return false
 		}
 
 		storeProduct = VirtusizeAPIService.getStoreProductInfoAsync(productId: productId).success
 		if storeProduct == nil {
 			Virtusize.showInPageError = true
-			return
+			return false
 		}
 
 		productTypes = VirtusizeAPIService.getProductTypesAsync().success
 		if productTypes == nil {
 			Virtusize.showInPageError = true
-			return
+			return false
 		}
 
 		i18nLocalization = VirtusizeAPIService.getI18nTextsAsync().success
 		if i18nLocalization == nil {
 			Virtusize.showInPageError = true
+			return false
 		}
+		return true
 	}
 
 	/// Fetches data for InPage recommendation
@@ -159,15 +162,10 @@ internal class VirtusizeRepository: NSObject {
 			}
 		}
 
-		guard let storeProduct = storeProduct,
-			  let productTypes = productTypes else {
-			return
-		}
-
 		if let userBodyProfile = userBodyProfile {
 			bodyProfileRecommendedSize = VirtusizeAPIService.getBodyProfileRecommendedSizeAsync(
-				productTypes: productTypes,
-				storeProduct: storeProduct,
+				productTypes: productTypes!,
+				storeProduct: storeProduct!,
 				userBodyProfile: userBodyProfile
 			).success
 		}
@@ -177,8 +175,8 @@ internal class VirtusizeRepository: NSObject {
 			userProducts.filter({ product in return product.id == selectedUserProductId }) : userProducts
 		sizeComparisonRecommendedSize = FindBestFitHelper.findBestFitProductSize(
 			userProducts: userProducts,
-			storeProduct: storeProduct,
-			productTypes: productTypes
+			storeProduct: storeProduct!,
+			productTypes: productTypes!
 		)
 	}
 

--- a/Source/VirtusizeRepository.swift
+++ b/Source/VirtusizeRepository.swift
@@ -34,11 +34,9 @@ internal class VirtusizeRepository: NSObject {
 
 	/// The session API response as a string
 	var userSessionResponse: String = ""
-
-	// This dictionary holds the information of which the memory address of a view points to which store product object
+	/// This dictionary holds the information of available vs views about which the memory address of a vs view points to which store product
 	var availableVSViewToProductDict = [String: VirtusizeInternalProduct]()
-
-	// This variable holds the data of the current store product from the Virtusize API
+	/// This variable holds the data of the current store product from the Virtusize API
 	var currentProduct: VirtusizeInternalProduct?
 	/// The array of `VirtusizeView` that clients use on their mobile application
 	var productTypes: [VirtusizeProductType]?
@@ -149,7 +147,7 @@ internal class VirtusizeRepository: NSObject {
 			currentProduct = storeProduct
 		}
 	}
-	
+
 	internal func getAvailableVirtusizeViewsBy(externalId: String?) -> [VirtusizeView] {
 		let availableViewMemoryAddress = availableVSViewToProductDict
 			.filter { $0.value.externalId == externalId }
@@ -158,8 +156,8 @@ internal class VirtusizeRepository: NSObject {
 			.filter { availableViewMemoryAddress.contains($0.memoryAddress) }
 	}
 
-	internal func cleanVirtusizeViewToProductDict(virtusizeViews: [VirtusizeView]) {
-		let deallocatedMemoryAddresses = virtusizeViews.filter { $0.isDeallocated == true }.map { $0.memoryAddress }
+	internal func cleanAvailableVSViewToProductDict() {
+		let deallocatedMemoryAddresses = Virtusize.virtusizeViews.filter { $0.isDeallocated == true }.map { $0.memoryAddress }
 		availableVSViewToProductDict = availableVSViewToProductDict
 			.filter { !deallocatedMemoryAddresses.contains($0.key) }
 	}

--- a/Virtusize.podspec
+++ b/Virtusize.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name = 'Virtusize'
-  s.version = '2.1.5'
+  s.version = '2.1.6'
   s.license = { :type => 'Copyright', :text => 'Copyright 2021 Virtusize' }
   s.summary = 'Integrate Virtusize on iOS devices'
   s.homepage = 'https://www.virtusize.com/'


### PR DESCRIPTION
- [x] Change the content mode of ProductImageView based on the product image type (USER or STORE)
- [x] Fix a crash related to com.apple.root.default-qos by setting up custom serial dispatch queues `com.virtusize.inpage-image-queue` and `com.virtusize.default-queue`
- [x] Fix an issue that InPage displayed the recommendation for the wrong product when there were multiple product pages opened in the navigation stack of a mobile app
- [x] Bump version to 2.1.6 