### PR TITLE
The SNS issue fix with the SDK

### DIFF
--- a/Example/Example.xcodeproj/project.pbxproj
+++ b/Example/Example.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		4DED8D4A20575A9C001CA7DF /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 4DED8D4820575A9C001CA7DF /* Main.storyboard */; };
 		4DED8D4C20575A9C001CA7DF /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 4DED8D4B20575A9C001CA7DF /* Assets.xcassets */; };
 		4DED8D4F20575A9C001CA7DF /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 4DED8D4D20575A9C001CA7DF /* LaunchScreen.storyboard */; };
+		9C454D0426686DD7003BF5BE /* WebViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C454D0326686DD7003BF5BE /* WebViewController.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -63,6 +64,7 @@
 		4DED8D4B20575A9C001CA7DF /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		4DED8D4E20575A9C001CA7DF /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		4DED8D5020575A9C001CA7DF /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		9C454D0326686DD7003BF5BE /* WebViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebViewController.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -112,6 +114,7 @@
 				4DED8D4620575A9C001CA7DF /* ViewController.swift */,
 				4DED8D4820575A9C001CA7DF /* Main.storyboard */,
 				4DED8D5720575BCD001CA7DF /* Supporting Files */,
+				9C454D0326686DD7003BF5BE /* WebViewController.swift */,
 			);
 			path = Example;
 			sourceTree = "<group>";
@@ -252,6 +255,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				4DED8D4720575A9C001CA7DF /* ViewController.swift in Sources */,
+				9C454D0426686DD7003BF5BE /* WebViewController.swift in Sources */,
 				4DED8D4520575A9C001CA7DF /* AppDelegate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -405,7 +409,7 @@
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = 32CS757VQK;
 				INFOPLIST_FILE = Example/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 10.3;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
@@ -421,7 +425,7 @@
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = 32CS757VQK;
 				INFOPLIST_FILE = Example/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 10.3;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";

--- a/Example/Example/ViewController.swift
+++ b/Example/Example/ViewController.swift
@@ -114,9 +114,24 @@ class ViewController: UIViewController {
         inPageStandard.centerXAnchor.constraint(equalTo: view.centerXAnchor).isActive = true
         inPageStandard.topAnchor.constraint(equalTo: inPageMini2.bottomAnchor, constant: 16).isActive = true
 
+		let webViewButton = UIButton()
+		webViewButton.backgroundColor = UIColor.black
+		webViewButton.setTitle("SNS Test", for: .normal)
+		webViewButton.contentEdgeInsets = UIEdgeInsets(top: 4, left: 4, bottom: 4, right: 4)
+		view.addSubview(webViewButton)
+		webViewButton.translatesAutoresizingMaskIntoConstraints = false
+		webViewButton.centerXAnchor.constraint(equalTo: view.centerXAnchor).isActive = true
+		webViewButton.topAnchor.constraint(equalTo: inPageStandard.bottomAnchor, constant: 16).isActive = true
+
+		webViewButton.addTarget(self, action: #selector(openWebView), for: .touchUpInside)
+
         // MARK: The Order API
         sendOrderSample()
     }
+
+	@objc func openWebView() {
+		present(WebViewController(), animated: true)
+	}
 
     /// Demonstrates how to send an order to the Virtusize server
     ///

--- a/Example/Example/WebViewController.swift
+++ b/Example/Example/WebViewController.swift
@@ -1,0 +1,93 @@
+//
+//  WebViewController.swift
+//
+//  Copyright (c) 2021-present Virtusize KK
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
+
+import UIKit
+import WebKit
+import Virtusize
+
+class WebViewController: UIViewController {
+
+	private var webView: VirtusizeWebView?
+
+	public convenience init() {
+		self.init(nibName: nil, bundle: nil)
+	}
+
+	public override func viewDidLoad() {
+		super.viewDidLoad()
+
+		let webView = VirtusizeWebView(frame: .zero)
+		webView.uiDelegate = self
+		view.addSubview(webView)
+		self.webView = webView
+
+		webView.translatesAutoresizingMaskIntoConstraints = false
+		if #available(iOS 11.0, *) {
+			let layoutGuide = view.safeAreaLayoutGuide
+			NSLayoutConstraint.activate([
+				webView.topAnchor.constraint(equalTo: layoutGuide.topAnchor),
+				webView.bottomAnchor.constraint(equalTo: layoutGuide.bottomAnchor),
+				webView.leadingAnchor.constraint(equalTo: layoutGuide.leadingAnchor),
+				webView.trailingAnchor.constraint(equalTo: layoutGuide.trailingAnchor)
+			])
+		} else {
+			let views = ["webView": webView]
+			let verticalConstraints = NSLayoutConstraint.constraints(
+				withVisualFormat: "V:|-20-[webView]-0-|",
+				options: .alignAllTop,
+				metrics: nil,
+				views: views)
+			let horizontalConstraints = NSLayoutConstraint.constraints(
+				withVisualFormat: "|-0-[webView]-0-|",
+				options: .alignAllLeft,
+				metrics: nil,
+				views: views)
+
+			NSLayoutConstraint.activate(verticalConstraints + horizontalConstraints)
+		}
+
+		webView.load(
+			URLRequest(
+				url: URL(
+					string: "https://virtusize-jp-demo.s3-ap-northeast-1.amazonaws.com/sns-auth-test/index.html")!
+			)
+		)
+	}
+}
+
+extension WebViewController: WKUIDelegate {
+	func webView(
+		_ webView: WKWebView,
+		createWebViewWith configuration: WKWebViewConfiguration,
+		for navigationAction: WKNavigationAction,
+		windowFeatures: WKWindowFeatures
+	) -> WKWebView? {
+		print("WebViewController: createWebViewWith")
+		return nil
+	}
+
+	func webViewDidClose(_ webView: WKWebView) {
+		print("WebViewController: webViewDidClose")
+	}
+}

--- a/Source/VirtusizeWebView.swift
+++ b/Source/VirtusizeWebView.swift
@@ -1,0 +1,88 @@
+//
+//  VirtusizeWebView.swift
+//
+//  Copyright (c) 2021-present Virtusize KK
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
+
+import WebKit
+
+fileprivate final class VSProcessPool: WKProcessPool {
+	static let pool = VSProcessPool()
+}
+
+open class VirtusizeWebView: WKWebView {
+
+	open override var uiDelegate: WKUIDelegate? {
+		didSet {
+			guard uiDelegate?.isEqual(self) == false else {
+				return
+			}
+
+			wkUIDelegate = uiDelegate
+			uiDelegate = self
+		}
+	}
+
+	private weak var wkUIDelegate: WKUIDelegate?
+
+	public init(frame: CGRect) {
+		let configuration = WKWebViewConfiguration()
+		configuration.processPool = VSProcessPool.pool
+		super.init(frame: frame, configuration: configuration)
+		uiDelegate = self
+	}
+
+	required public init?(coder: NSCoder) {
+		fatalError("init(coder:) has not been implemented")
+	}
+}
+
+extension VirtusizeWebView: WKUIDelegate {
+
+	open func webView(
+		_ webView: WKWebView,
+		createWebViewWith configuration: WKWebViewConfiguration,
+		for navigationAction: WKNavigationAction,
+		windowFeatures: WKWindowFeatures
+	) -> WKWebView? {
+		guard let targetFrame = navigationAction.targetFrame, targetFrame.isMainFrame else {
+			// By default, the Google sign-in page shows a 403 error: disallowed_useragent if you are visiting it within a web view.
+			// By setting up the user agent, Google recognizes the web view as a Safari browser
+			configuration.applicationNameForUserAgent = "CriOS/56.0.2924.75 Mobile/14E5239e Safari/602.1"
+			let popupWebView = WKWebView(frame: webView.frame, configuration: configuration)
+			popupWebView.uiDelegate = self
+			webView.addSubview(popupWebView)
+			return popupWebView
+		}
+
+		return wkUIDelegate?.webView?(
+			webView,
+			createWebViewWith: configuration,
+			for: navigationAction,
+			windowFeatures: windowFeatures
+		)
+	}
+
+	open func webViewDidClose(_ webView: WKWebView) {
+		webView.removeFromSuperview()
+		wkUIDelegate?.webViewDidClose?(webView)
+	}
+}

--- a/Source/VirtusizeWebView.swift
+++ b/Source/VirtusizeWebView.swift
@@ -43,9 +43,10 @@ open class VirtusizeWebView: WKWebView {
 
 	private weak var wkUIDelegate: WKUIDelegate?
 
-	public init(frame: CGRect) {
+	// wkProcessPool can be passed for cookies sharing across different web views
+	public init(frame: CGRect, wkProcessPool: WKProcessPool? = nil) {
 		let configuration = WKWebViewConfiguration()
-		configuration.processPool = VSProcessPool.pool
+		configuration.processPool = wkProcessPool ?? VSProcessPool.pool
 		super.init(frame: frame, configuration: configuration)
 		uiDelegate = self
 	}

--- a/Source/VirtusizeWebView.swift
+++ b/Source/VirtusizeWebView.swift
@@ -96,7 +96,95 @@ extension VirtusizeWebView: WKUIDelegate {
 		webView.removeFromSuperview()
 		wkUIDelegate?.webViewDidClose?(webView)
 	}
-	
+
+	open func webView(
+		_ webView: WKWebView,
+		runJavaScriptAlertPanelWithMessage message: String,
+		initiatedByFrame frame: WKFrameInfo,
+		completionHandler: @escaping () -> Void
+	) {
+		wkUIDelegate?.webView?(
+			webView,
+			runJavaScriptAlertPanelWithMessage: message,
+			initiatedByFrame: frame,
+			completionHandler: completionHandler
+		)
+	}
+
+	open func webView(
+		_ webView: WKWebView,
+		runJavaScriptConfirmPanelWithMessage message: String,
+		initiatedByFrame frame: WKFrameInfo,
+		completionHandler: @escaping (Bool) -> Void
+	) {
+		wkUIDelegate?.webView?(
+			webView,
+			runJavaScriptConfirmPanelWithMessage: message,
+			initiatedByFrame: frame,
+			completionHandler: completionHandler
+		)
+	}
+
+	open func webView(
+		_ webView: WKWebView,
+		runJavaScriptTextInputPanelWithPrompt prompt: String,
+		defaultText: String?,
+		initiatedByFrame frame: WKFrameInfo,
+		completionHandler: @escaping (String?) -> Void
+	) {
+		wkUIDelegate?.webView?(
+			webView,
+			runJavaScriptTextInputPanelWithPrompt: prompt,
+			defaultText: defaultText,
+			initiatedByFrame: frame,
+			completionHandler: completionHandler
+		)
+	}
+
+	open func webView(_ webView: WKWebView, shouldPreviewElement elementInfo: WKPreviewElementInfo) -> Bool {
+		wkUIDelegate?.webView?(webView, shouldPreviewElement: elementInfo) ?? false
+	}
+
+	open func webView(
+		_ webView: WKWebView,
+		previewingViewControllerForElement elementInfo: WKPreviewElementInfo,
+		defaultActions previewActions: [WKPreviewActionItem]
+	) -> UIViewController? {
+		wkUIDelegate?.webView?(webView, previewingViewControllerForElement: elementInfo, defaultActions: previewActions)
+	}
+
+	open func webView(_ webView: WKWebView, commitPreviewingViewController previewingViewController: UIViewController) {
+		wkUIDelegate?.webView?(webView, commitPreviewingViewController: previewingViewController)
+	}
+
+	@available(iOS 13.0, *)
+	open func webView(
+		_ webView: WKWebView,
+		contextMenuConfigurationForElement elementInfo: WKContextMenuElementInfo,
+		completionHandler: @escaping (UIContextMenuConfiguration?) -> Void
+	) {
+		wkUIDelegate?.webView?(webView, contextMenuConfigurationForElement: elementInfo, completionHandler: completionHandler)
+	}
+
+	@available(iOS 13.0, *)
+	open func webView(_ webView: WKWebView, contextMenuWillPresentForElement elementInfo: WKContextMenuElementInfo) {
+		wkUIDelegate?.webView?(webView, contextMenuWillPresentForElement: elementInfo)
+	}
+
+	@available(iOS 13.0, *)
+	open func webView(
+		_ webView: WKWebView,
+		contextMenuForElement elementInfo: WKContextMenuElementInfo,
+		willCommitWithAnimator animator: UIContextMenuInteractionCommitAnimating
+	) {
+		uiDelegate?.webView?(webView, contextMenuForElement: elementInfo, willCommitWithAnimator: animator)
+	}
+
+	@available(iOS 13.0, *)
+	open func webView(_ webView: WKWebView, contextMenuDidEndForElement elementInfo: WKContextMenuElementInfo) {
+		uiDelegate?.webView?(webView, contextMenuDidEndForElement: elementInfo)
+	}
+
 	/// Checks if a URL is an external link from Virtusize to be open on the Safari browser
 	private func isExternalLinkFromVirtusize(url: String?) -> Bool {
 		return url != nil && (url!.contains("surveymonkey") || (url!.contains("virtusize") && url!.contains("privacy")))

--- a/Virtusize.xcodeproj/project.pbxproj
+++ b/Virtusize.xcodeproj/project.pbxproj
@@ -46,6 +46,7 @@
 		9C3DE36C25BA8A160082C140 /* Colors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C3DE36B25BA8A160082C140 /* Colors.swift */; };
 		9C3DE37725BA9CC70082C140 /* VirtusizeWebViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C3DE37625BA9CC70082C140 /* VirtusizeWebViewController.swift */; };
 		9C4378D7253444F600E8729A /* UserSessionInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C4378D6253444F600E8729A /* UserSessionInfo.swift */; };
+		9C454D0B2669F516003BF5BE /* VirtusizeWebView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C454D0A2669F516003BF5BE /* VirtusizeWebView.swift */; };
 		9C4B9D722491EC5D0065808E /* APIEndpointsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C4B9D712491EC5D0065808E /* APIEndpointsTests.swift */; };
 		9C58751C24EF7D2500352474 /* VirtusizeInPageMini.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C58751B24EF7D2500352474 /* VirtusizeInPageMini.swift */; };
 		9C58751E24EF7D5000352474 /* VirtusizeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C58751D24EF7D5000352474 /* VirtusizeView.swift */; };
@@ -155,6 +156,7 @@
 		9C3DE36B25BA8A160082C140 /* Colors.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Colors.swift; path = Source/Internal/Constants/Colors.swift; sourceTree = "<group>"; };
 		9C3DE37625BA9CC70082C140 /* VirtusizeWebViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VirtusizeWebViewController.swift; sourceTree = "<group>"; };
 		9C4378D6253444F600E8729A /* UserSessionInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserSessionInfo.swift; sourceTree = "<group>"; };
+		9C454D0A2669F516003BF5BE /* VirtusizeWebView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VirtusizeWebView.swift; sourceTree = "<group>"; };
 		9C4B9D712491EC5D0065808E /* APIEndpointsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIEndpointsTests.swift; sourceTree = "<group>"; };
 		9C58751B24EF7D2500352474 /* VirtusizeInPageMini.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VirtusizeInPageMini.swift; sourceTree = "<group>"; };
 		9C58751D24EF7D5000352474 /* VirtusizeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VirtusizeView.swift; sourceTree = "<group>"; };
@@ -287,6 +289,7 @@
 				9C35F99C25F02CAD0004E9CD /* VirtusizeAssets.xcassets */,
 				9C35F96625F02AC30004E9CD /* Resources */,
 				4D6C5792205FB9BA00DA910E /* Virtusize.swift */,
+				9C454D0A2669F516003BF5BE /* VirtusizeWebView.swift */,
 				9CFF40C825B5C9D500B21D4E /* VirtusizeRepository.swift */,
 				9C787FC825DB793400346F2A /* VirtusizeEventHandler.swift */,
 				DFFAA96321A39BFC000F0F70 /* UI */,
@@ -694,6 +697,7 @@
 				9C132F3025D258B00077FC73 /* Base64ImageString.swift in Sources */,
 				9C132F2D25D258A50077FC73 /* UserDefaultsHelper.swift in Sources */,
 				9CA6820F24BC709300ADA871 /* VirtusizeParamsBuilder.swift in Sources */,
+				9C454D0B2669F516003BF5BE /* VirtusizeWebView.swift in Sources */,
 				9CEAB7AE24D67EBE00F969E1 /* HTTPURLResponse+Extensions.swift in Sources */,
 				9CB98B9C24B2C5B400C51F20 /* VirtusizeRegion.swift in Sources */,
 				9C3DE36C25BA8A160082C140 /* Colors.swift in Sources */,


### PR DESCRIPTION
## Summary
The main idea is that clients can replace their WKWebview with VirtusizeWebview and still can use all the functionalities that WKWebview provides.
There's an issue about x-vs-auth being not persistent in the local storage on our domain such as staging.virtusize.com once a user force-closes the iOS app. It might not be an urgent deal because right now this is how it currently works with the Virtusize log in flow on client's web view apps. 
Wes and I are planing to solve it by exchanging x-vs-auth between SDK and Virtusize integration (previously called Aoyama) and save this token in the app's storage to avoid any issues that might be potentially caused by cookies and local storage.

## Demo
![Jun-04-2021 16-10-34](https://user-images.githubusercontent.com/7802052/120760793-7e7ad700-c54f-11eb-8b47-4c1a577a47b8.gif)

If the app is killed, the user won't be logged in anymore
![Jun-04-2021 16-10-51](https://user-images.githubusercontent.com/7802052/120760802-80449a80-c54f-11eb-8c2c-0fc1b0d945bc.gif)