### PR TITLE
Release/2.2

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,9 @@ Use list notation, and following prefixes:
 
 ## NEXT RELEASE for Version 2.x.x
 
+### 2.2
+- Feature: Fix SNS Login on the web version of Virtusize integration through the SDK
+
 ### 2.1.6
 - Bugfix: Fix a crash related to com.apple.root.default-qos
 - Bugfix: Fix InPage loading the wrong product issue when there are multiple product pages opened in the navigation stack of a mobile app

--- a/README-JP.md
+++ b/README-JP.md
@@ -21,6 +21,35 @@ You need a unique API key and an Admin account, only available to Virtusize cust
 
 
 
+## Table of Contents
+
+- [対応バージョン](#対応バージョン)
+- [はじめに](#installation)
+  - [CocoaPods](#cocoapods)
+  - [Carthage](#carthage)
+- [セットアップ](#setup)
+  - [はじめに](#1-はじめに)
+  - [商品詳細をセットする](#2-商品詳細をセットする)
+  - [VirtusizeMessageHandlerの実装（オプション）](#3-virtusizemessagehandlerの実装オプション)
+  - [クッキー共有の許可（オプション）](#4-クッキー共有の許可オプション)
+  - [製品データチェックを聞く（オプション）](#5-製品データチェックを聞くオプション)
+- [Virtusize Views](#virtusize-views)
+  - [バーチャサイズ・ボタン（Virtusize Button）](#1-バーチャサイズボタンvirtusize-button)
+  - [バーチャサイズ・インページ（Virtuzie InPage）](#2-バーチャサイズインページvirtuzie-inpage)
+    - [InPage Standard](#2-inpage-standard)
+    - [InPage Mini](#3-inpage-mini)
+- [The Order API](#the-order-api)
+  - [初期化](#1-初期化)
+  - [注文データ向けに*VirtusizeOrder* オブジェクトを作成](#2--注文データ向けにvirtusizeorder-オブジェクトを作成)
+  - [注文情報の送信](#3-注文情報の送信) 
+- [Fix SNS Login in Virtusize for native Webview apps](#fix-sns-login-in-virtusize-for-native-webview-apps)
+- [Build](#build)
+- [Run all tests](#run-all-tests)
+- [Roadmap](#roadmap)
+- [License](#license)
+
+
+
 ## 対応バージョン
 
 - iOS 10.3+
@@ -47,7 +76,7 @@ platform :ios, '10.3'
 use_frameworks!
 
 target '<your-target-name>' do
-pod 'Virtusize', '~> 2.1.6'
+pod 'Virtusize', '~> 2.2'
 end
 ```
 
@@ -584,6 +613,42 @@ Virtusize.sendOrder(
     onError: { error in
         print("Failed to send the order, error: \(error.debugDescription)")
 })
+```
+
+
+
+## Fix SNS Login in Virtusize for native Webview apps
+
+The built-in WKWebView blocks any popup windows by default. To allow users sign up or log in with the web version of Virtusize integration in your webview, please use this method: 
+
+1. If you build your UI purely with UIKit, replace your `WKWebView` with **`VirtusizeWebView`** in your Swift file
+
+   - Swift
+
+   ```diff
+   - var webView: WKWebView
+   + var webView: VirtusizeWebView
+   ```
+
+2. If you build your UI with Xcode's Interface Builder, make sure that you set the Custom Class of your webview to **`VirtusizeWebView`** in the Identity inspector to fix SNS login in Virtusize.
+
+   - Swift
+
+   ```diff
+   - @IBOutlet weak var webview: WKWebView!
+   + @IBOutlet weak var webview: VirtusizeWebView!
+   ```
+
+   - Interface Builder
+
+     ![](https://user-images.githubusercontent.com/7802052/121308895-87e3b500-c93c-11eb-8745-f4bf22bccdba.png)
+
+
+
+If you want to allow cookie sharing arcoss different instances of VirtusizeWebView, please assign your WKProcessPool to Virtusize.processPool
+
+```swift
+Virtusize.processPool = WKProcessPool()
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,35 @@ You need a unique API key and an Admin account, only available to Virtusize cust
 
 
 
+## Table of Contents
+
+- [Requirements](#requirements)
+- [Installation](#installation)
+  - [CocoaPods](#cocoapods)
+  - [Carthage](#carthage)
+- [Setup](#setup)
+  - [Initialization](#1-initialization)
+  - [Set Up Product Details](#2-set-up-product-details)
+  - [Implement VirtusizeMessageHandler (Optional)](#3-implement-virtusizemessagehandler-optional)
+  - [Allow Cookie Sharing (Optional)](#4-allow-cookie-sharing-optional)
+  - [Listen to Product Data Check (Optional)](#5-listen-to-product-data-check-optional)
+- [Virtusize Views](#virtusize-views)
+  - [Virtusize Button](#1-virtusize-button)
+  - [Virtusize InPage](#2-virtusize-inpage)
+    - [InPage Standard](#2-inpage-standard)
+    - [InPage Mini](#3-inpage-mini)
+- [The Order API](#the-order-api)
+  - [Initialization](#1-initialization)
+  - [Create a *VirtusizeOrder* structure for order data](#2-create-a-virtusizeorder-structure-for-order-data)
+  - [Send an Order](#3-send-an-order) 
+- [Fix SNS Login in Virtusize for native Webview apps](#fix-sns-login-in-virtusize-for-native-webview-apps)
+- [Build](#build)
+- [Run all tests](#run-all-tests)
+- [Roadmap](#roadmap)
+- [License](#license)
+
+
+
 ## Requirements
 
 - iOS 10.3+
@@ -49,7 +78,7 @@ platform :ios, '10.3'
 use_frameworks!
 
 target '<your-target-name>' do
-pod 'Virtusize', '~> 2.1.6'
+pod 'Virtusize', '~> 2.2'
 end
 ```
 
@@ -569,19 +598,61 @@ Virtusize.sendOrder(
 })
 ```
 
+
+
+## Fix SNS Login in Virtusize for native Webview apps
+
+The built-in WKWebView blocks any popup windows by default. To allow users sign up or log in with the web version of Virtusize integration in your webview, please use this method: 
+
+1. If you build your UI purely with UIKit, replace your `WKWebView` with **`VirtusizeWebView`** in your Swift file
+
+   - Swift
+
+   ```diff
+   - var webView: WKWebView
+   + var webView: VirtusizeWebView
+   ```
+
+2. If you build your UI with Xcode's Interface Builder, make sure that you set the Custom Class of your webview to **`VirtusizeWebView`** in the Identity inspector to fix SNS login in Virtusize.
+
+   - Swift
+
+   ```diff
+   - @IBOutlet weak var webview: WKWebView!
+   + @IBOutlet weak var webview: VirtusizeWebView!
+   ```
+
+   - Interface Builder
+   
+     ![](https://user-images.githubusercontent.com/7802052/121308895-87e3b500-c93c-11eb-8745-f4bf22bccdba.png)
+
+If you want to allow cookie sharing arcoss different instances of VirtusizeWebView, please assign your WKProcessPool to Virtusize.processPool
+
+```swift
+Virtusize.processPool = WKProcessPool()
+```
+
+
+
 ## Build
 
 You need to install [SwiftLint](https://github.com/realm/SwiftLint).
 
     make build
 
+
+
 ## Run all tests
 
     make test
 
+
+
 ## Roadmap
 
 Please check the [Roadmap](ROADMAP.md) to find upcoming features and expected release dates.
+
+
 
 ## License
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,8 +1,14 @@
 # ROADMAP
 
-## 2.1.1
+## 2.2
 
 ### Release date: 
+
+- [x] Fix SNS Login on the web version of Virtusize integration through the SDK
+
+## 2.1.1
+
+### Release date: 21/03/04
 
 - [x] InPage integration
 

--- a/Source/VirtusizeWebView.swift
+++ b/Source/VirtusizeWebView.swift
@@ -43,10 +43,9 @@ open class VirtusizeWebView: WKWebView {
 
 	private weak var wkUIDelegate: WKUIDelegate?
 
-	// wkProcessPool can be passed for cookies sharing across different web views
-	public init(frame: CGRect, wkProcessPool: WKProcessPool? = nil) {
+	public init(frame: CGRect) {
 		let configuration = WKWebViewConfiguration()
-		configuration.processPool = wkProcessPool ?? VSProcessPool.pool
+		configuration.processPool = Virtusize.processPool ?? VSProcessPool.pool
 		super.init(frame: frame, configuration: configuration)
 		uiDelegate = self
 	}

--- a/Virtusize.podspec
+++ b/Virtusize.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name = 'Virtusize'
-  s.version = '2.1.6'
+  s.version = '2.2'
   s.license = { :type => 'Copyright', :text => 'Copyright 2021 Virtusize' }
   s.summary = 'Integrate Virtusize on iOS devices'
   s.homepage = 'https://www.virtusize.com/'


### PR DESCRIPTION
- [x] Allow users to assign the WKProcessPool to Virtusize.processPool to allow cookie sharing between multiple VirtusizeWebViews instead of passing it as a parameter of VirtusizeWebView
- [x] Write the README to explain how to integrate the SDK for fixing the SNS issue
- [x] Bump version to 2.2 