### PR TITLE
Hotfix/2.2.2

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,9 @@ Use list notation, and following prefixes:
 
 ## NEXT RELEASE for Version 2.x.x
 
+### 2.2.2
+- Bugfix: Fix a crash related to forcing unwrap an optional value
+
 ### 2.2.1
 - Feature: Fix SNS Login on the web version of Virtusize integration through the SDK
 

--- a/README-JP.md
+++ b/README-JP.md
@@ -76,7 +76,7 @@ platform :ios, '10.3'
 use_frameworks!
 
 target '<your-target-name>' do
-pod 'Virtusize', '~> 2.2.1'
+pod 'Virtusize', '~> 2.2.2'
 end
 ```
 

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ platform :ios, '10.3'
 use_frameworks!
 
 target '<your-target-name>' do
-pod 'Virtusize', '~> 2.2.1'
+pod 'Virtusize', '~> 2.2.2'
 end
 ```
 

--- a/Source/UI/VirtusizeInPageMini.swift
+++ b/Source/UI/VirtusizeInPageMini.swift
@@ -73,6 +73,7 @@ public class VirtusizeInPageMini: VirtusizeInPageView {
     }
 
     public override func setInPageRecommendation(
+		_ externalProductId: String?,
 		_ sizeComparisonRecommendedSize: SizeComparisonRecommendedSize?,
 		_ bodyProfileRecommendedSize: BodyProfileRecommendedSize?
 	) {

--- a/Source/UI/VirtusizeInPageStandard.swift
+++ b/Source/UI/VirtusizeInPageStandard.swift
@@ -112,7 +112,7 @@ public class VirtusizeInPageStandard: VirtusizeInPageView {
 	}
 
 	private func bind(to viewModel: VirtusizeInPageStandardViewModel) {
-		viewModel.userProductImage.observe(on: self) { [weak self] in
+		viewModel.userProductImageObservable.observe(on: self) { [weak self] in
 			if $0 != nil {
 				self?.userProductImageView.image = $0!.image
 				if $0!.source == .local {
@@ -122,7 +122,7 @@ public class VirtusizeInPageStandard: VirtusizeInPageView {
 			}
 		}
 
-		viewModel.storeProductImage.observe(on: self) { [weak self] in
+		viewModel.storeProductImageObservable.observe(on: self) { [weak self] in
 			if $0 != nil {
 				self?.storeProductImageView.image = $0!.image
 				if $0!.source == .local {
@@ -135,7 +135,7 @@ public class VirtusizeInPageStandard: VirtusizeInPageView {
 
 	private func setProductImages() {
 		if bestFitUserProduct != nil {
-			if viewModel.storeProductImage.value != nil  && viewModel.userProductImage.value != nil {
+			if viewModel.storeProductImageObservable.value != nil  && viewModel.userProductImageObservable.value != nil {
 				if inPageStandardView.frame.size.width >= smallInPageWidth {
 					adjustProductImageViewPosition(userProductImageSize: 40, productImageViewOffset: -2)
 				} else {
@@ -148,7 +148,7 @@ public class VirtusizeInPageStandard: VirtusizeInPageView {
 				finishLoading()
 			}
 		} else {
-			if viewModel.storeProductImage.value != nil {
+			if viewModel.storeProductImageObservable.value != nil {
 				if inPageStandardView.frame.size.width < smallInPageWidth {
 					// if item to item recommendation is not available, stop any fading animations
 					stopCrossFadeProductImageViews()
@@ -171,8 +171,8 @@ public class VirtusizeInPageStandard: VirtusizeInPageView {
 	}
 
 	private func unbind(to viewModel: VirtusizeInPageStandardViewModel) {
-		viewModel.userProductImage.remove(observer: self)
-		viewModel.storeProductImage.remove(observer: self)
+		viewModel.userProductImageObservable.remove(observer: self)
+		viewModel.storeProductImageObservable.remove(observer: self)
 	}
 
     private func addSubviews() {
@@ -439,6 +439,7 @@ public class VirtusizeInPageStandard: VirtusizeInPageView {
     }
 
 	public override func setInPageRecommendation(
+		_ externalProductId: String?,
 		_ sizeComparisonRecommendedSize: SizeComparisonRecommendedSize?,
 		_ bodyProfileRecommendedSize: BodyProfileRecommendedSize?
 	) {
@@ -451,7 +452,7 @@ public class VirtusizeInPageStandard: VirtusizeInPageView {
 		if let bestFitUserProduct = bestFitUserProduct {
 			viewModel.loadUserProductImage(bestFitUserProduct: bestFitUserProduct)
 		}
-		viewModel.loadStoreProductImage()
+		viewModel.loadStoreProductImage(storeProductId: externalProductId)
 	}
 
 	private func adjustProductImageViewPosition(userProductImageSize: CGFloat, productImageViewOffset: CGFloat) {

--- a/Source/UI/VirtusizeInPageView.swift
+++ b/Source/UI/VirtusizeInPageView.swift
@@ -100,6 +100,7 @@ public class VirtusizeInPageView: UIView, VirtusizeView {
 
 	/// A parent function to set up InPage recommendation
 	internal func setInPageRecommendation(
+		_ externalProductId: String?,
 		_ sizeComparisonRecommendedSize: SizeComparisonRecommendedSize?,
 		_ bodyProfileRecommendedSize: BodyProfileRecommendedSize?
 	) {}

--- a/Source/Virtusize.swift
+++ b/Source/Virtusize.swift
@@ -62,43 +62,43 @@ public class Virtusize {
 
 	internal static let dispatchQueue = DispatchQueue(label: "com.virtusize.default-queue")
 
-	/// The internal property for product
-	internal static var productWithPDCData: VirtusizeProduct?
+	/// The private property for product
+	private static var privateProduct: VirtusizeProduct?
 	/// The Virtusize product to get the value from the`productDataCheck` request
 	public static var product: VirtusizeProduct? {
 		set {
-			guard let newValue = newValue else {
+			guard let product = newValue else {
 				return
 			}
 
-			productWithPDCData = newValue
-
 			dispatchQueue.async {
-				guard virtusizeRepository.isProductValid(product: newValue) else {
-					DispatchQueue.main.async {
-						for virtusizeView in activeVirtusizeViews {
-							(virtusizeView as? UIView)?.isHidden = true
+				virtusizeRepository.checkProductValidity(product: product) { productWithPDCData in
+					if let productWithPDCData = productWithPDCData {
+						privateProduct = productWithPDCData
+						DispatchQueue.main.async {
+							for virtusizeView in activeVirtusizeViews {
+								(virtusizeView as? VirtusizeInPageView)?.setup()
+								virtusizeView.isLoading()
+							}
+						}
+
+						virtusizeRepository.fetchInitialData(productId: productWithPDCData.productCheckData?.productDataId) {
+							virtusizeRepository.updateUserSession()
+							virtusizeRepository.fetchDataForInPageRecommendation()
+							virtusizeRepository.switchInPageRecommendation()
+						}
+					} else {
+						DispatchQueue.main.async {
+							for virtusizeView in activeVirtusizeViews {
+								(virtusizeView as? UIView)?.isHidden = true
+							}
 						}
 					}
-					return
-				}
-
-				DispatchQueue.main.async {
-					for virtusizeView in activeVirtusizeViews {
-						(virtusizeView as? VirtusizeInPageView)?.setup()
-						virtusizeView.isLoading()
-					}
-				}
-
-				if virtusizeRepository.fetchInitialData(productId: productWithPDCData!.productCheckData!.productDataId) {
-					virtusizeRepository.updateUserSession()
-					virtusizeRepository.fetchDataForInPageRecommendation()
-					virtusizeRepository.switchInPageRecommendation()
 				}
 			}
 		}
 		get {
-			return productWithPDCData
+			return privateProduct
 		}
 	}
 
@@ -116,7 +116,9 @@ public class Virtusize {
 			if newValue?.1 != nil || newValue?.2 != nil {
 				DispatchQueue.main.async {
 					for virtusizeView in virtusizeRepository.getAvailableVirtusizeViewsBy(externalId: newValue?.0?.externalId) {
-						(virtusizeView as? VirtusizeInPageView)?.setInPageRecommendation(newValue?.1, newValue?.2)
+						(virtusizeView as? VirtusizeInPageView)?.setInPageRecommendation(
+							newValue?.0?.externalId, newValue?.1, newValue?.2
+						)
 					}
 					self.updateInPageViews = (newValue?.0, nil, nil)
 				}

--- a/Virtusize.podspec
+++ b/Virtusize.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name = 'Virtusize'
-  s.version = '2.2.1'
+  s.version = '2.2.2'
   s.license = { :type => 'Copyright', :text => 'Copyright 2021 Virtusize' }
   s.summary = 'Integrate Virtusize on iOS devices'
   s.homepage = 'https://www.virtusize.com/'

--- a/Virtusize.xcodeproj/project.pbxproj
+++ b/Virtusize.xcodeproj/project.pbxproj
@@ -960,7 +960,6 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 10.3;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 2.1.5;
 				PRODUCT_BUNDLE_IDENTIFIER = com.virtusize.Virtusize;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
@@ -984,7 +983,6 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 10.3;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 2.1.5;
 				PRODUCT_BUNDLE_IDENTIFIER = com.virtusize.Virtusize;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;


### PR DESCRIPTION
## Summary
- [x] Fix a crash about forcing unwrapping an optional value in the Virtusize.product setter
- [x] Change the visibility of Virtusize.productWithPDCData (the name is changed to Virtusize.privateProduct) from internal to private
- [x] Bump version to 2.2.2 