### PR TITLE
Feature: Enable SNS buttons for the webview

### DIFF
--- a/Example/Example/WebViewController.swift
+++ b/Example/Example/WebViewController.swift
@@ -41,6 +41,7 @@ class WebViewController: UIViewController {
 			// set the configuration here
 		}
 		webView.uiDelegate = self
+		webView.navigationDelegate = self
 		view.addSubview(webView)
 		self.webView = webView
 
@@ -91,5 +92,11 @@ extension WebViewController: WKUIDelegate {
 
 	func webViewDidClose(_ webView: WKWebView) {
 		print("WebViewController: webViewDidClose")
+	}
+}
+
+extension WebViewController: WKNavigationDelegate {
+	func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
+		print("WebViewController: didFinish")
 	}
 }

--- a/Example/Example/WebViewController.swift
+++ b/Example/Example/WebViewController.swift
@@ -99,4 +99,9 @@ extension WebViewController: WKNavigationDelegate {
 	func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
 		print("WebViewController: didFinish")
 	}
+
+	func webView(_ webView: WKWebView, decidePolicyFor navigationResponse: WKNavigationResponse, decisionHandler: @escaping (WKNavigationResponsePolicy) -> Void) {
+		print("WebViewController: decidePolicyFor")
+		decisionHandler(.allow)
+	}
 }

--- a/Source/UI/VirtusizeWebViewController.swift
+++ b/Source/UI/VirtusizeWebViewController.swift
@@ -144,6 +144,7 @@ extension VirtusizeWebViewController: WKNavigationDelegate, WKUIDelegate {
             return
         }
         webView.evaluateJavaScript(vsParamsFromSDKScript, completionHandler: nil)
+		webView.evaluateJavaScript("window.virtusizeSNSEnabled = true;", completionHandler: nil)
         checkAndUpdateBrowserID()
     }
 

--- a/Source/VirtusizeWebView.swift
+++ b/Source/VirtusizeWebView.swift
@@ -172,7 +172,11 @@ extension VirtusizeWebView: WKUIDelegate {
 		previewingViewControllerForElement elementInfo: WKPreviewElementInfo,
 		defaultActions previewActions: [WKPreviewActionItem]
 	) -> UIViewController? {
-		return wkUIDelegate?.webView?(webView, previewingViewControllerForElement: elementInfo, defaultActions: previewActions)
+		return wkUIDelegate?.webView?(
+			webView,
+			previewingViewControllerForElement: elementInfo,
+			defaultActions: previewActions
+		)
 	}
 
 	public func webView(_ webView: WKWebView, commitPreviewingViewController previewingViewController: UIViewController) {
@@ -185,7 +189,11 @@ extension VirtusizeWebView: WKUIDelegate {
 		contextMenuConfigurationForElement elementInfo: WKContextMenuElementInfo,
 		completionHandler: @escaping (UIContextMenuConfiguration?) -> Void
 	) {
-		if wkUIDelegate?.webView?(webView, contextMenuConfigurationForElement: elementInfo, completionHandler: completionHandler) == nil {
+		if wkUIDelegate?.webView?(
+			webView,
+			contextMenuConfigurationForElement: elementInfo,
+			completionHandler: completionHandler
+		) == nil {
 			completionHandler(nil)
 		}
 	}
@@ -227,7 +235,19 @@ extension VirtusizeWebView: WKNavigationDelegate {
 		decidePolicyFor navigationAction: WKNavigationAction,
 		decisionHandler: @escaping (WKNavigationActionPolicy) -> Swift.Void
 	) {
-		if wkNavigationDelegate?.webView?(webView, decidePolicyFor: navigationAction, decisionHandler: decisionHandler) == nil {
+		if let url = webView.url, isExternalLinkFromVirtusize(url: url.absoluteString) {
+			if let sharedApplication = UIApplication.safeShared {
+				decisionHandler(.cancel)
+				sharedApplication.safeOpenURL(url)
+				return
+			}
+		}
+
+		if wkNavigationDelegate?.webView?(
+			webView,
+			decidePolicyFor: navigationAction,
+			decisionHandler: decisionHandler
+		) == nil {
 			decisionHandler(.allow)
 		}
 	}
@@ -257,7 +277,11 @@ extension VirtusizeWebView: WKNavigationDelegate {
 		decisionHandler: @escaping (WKNavigationResponsePolicy
 		) ->
 							Swift.Void) {
-		if wkNavigationDelegate?.webView?(webView, decidePolicyFor: navigationResponse, decisionHandler: decisionHandler) == nil {
+		if wkNavigationDelegate?.webView?(
+			webView,
+			decidePolicyFor: navigationResponse,
+			decisionHandler: decisionHandler
+		) == nil {
 			decisionHandler(.allow)
 		}
 	}

--- a/Source/VirtusizeWebView.swift
+++ b/Source/VirtusizeWebView.swift
@@ -43,22 +43,37 @@ open class VirtusizeWebView: WKWebView {
 
 	private weak var wkUIDelegate: WKUIDelegate?
 
+	open override var navigationDelegate: WKNavigationDelegate? {
+		didSet {
+			guard navigationDelegate?.isEqual(self) == false else {
+				return
+			}
+
+			wkNavigationDelegate = navigationDelegate
+			navigationDelegate = self
+		}
+	}
+
+	private weak var wkNavigationDelegate: WKNavigationDelegate?
+
 	public init(frame: CGRect, configurationClosure: ((WKWebViewConfiguration) -> Void)? = nil) {
 		let configuration = WKWebViewConfiguration()
 		configuration.processPool = VSProcessPool.pool
 		configurationClosure?(configuration)
 		super.init(frame: frame, configuration: configuration)
 		uiDelegate = self
+		navigationDelegate = self
 	}
 
 	required public init?(coder: NSCoder) {
 		super.init(coder: coder)
 		uiDelegate = self
+		navigationDelegate = self
 	}
 }
 
 extension VirtusizeWebView: WKUIDelegate {
-	open func webView(
+	public func webView(
 		_ webView: WKWebView,
 		createWebViewWith configuration: WKWebViewConfiguration,
 		for navigationAction: WKNavigationAction,
@@ -93,87 +108,95 @@ extension VirtusizeWebView: WKUIDelegate {
 		)
 	}
 
-	open func webViewDidClose(_ webView: WKWebView) {
+	public func webViewDidClose(_ webView: WKWebView) {
 		webView.removeFromSuperview()
 		wkUIDelegate?.webViewDidClose?(webView)
 	}
 
-	open func webView(
+	public func webView(
 		_ webView: WKWebView,
 		runJavaScriptAlertPanelWithMessage message: String,
 		initiatedByFrame frame: WKFrameInfo,
 		completionHandler: @escaping () -> Void
 	) {
-		wkUIDelegate?.webView?(
+		if wkUIDelegate?.webView?(
 			webView,
 			runJavaScriptAlertPanelWithMessage: message,
 			initiatedByFrame: frame,
 			completionHandler: completionHandler
-		)
+		) == nil {
+			completionHandler()
+		}
 	}
 
-	open func webView(
+	public func webView(
 		_ webView: WKWebView,
 		runJavaScriptConfirmPanelWithMessage message: String,
 		initiatedByFrame frame: WKFrameInfo,
 		completionHandler: @escaping (Bool) -> Void
 	) {
-		wkUIDelegate?.webView?(
+		if wkUIDelegate?.webView?(
 			webView,
 			runJavaScriptConfirmPanelWithMessage: message,
 			initiatedByFrame: frame,
 			completionHandler: completionHandler
-		)
+		) == nil {
+			completionHandler(false)
+		}
 	}
 
-	open func webView(
+	public func webView(
 		_ webView: WKWebView,
 		runJavaScriptTextInputPanelWithPrompt prompt: String,
 		defaultText: String?,
 		initiatedByFrame frame: WKFrameInfo,
 		completionHandler: @escaping (String?) -> Void
 	) {
-		wkUIDelegate?.webView?(
+		if wkUIDelegate?.webView?(
 			webView,
 			runJavaScriptTextInputPanelWithPrompt: prompt,
 			defaultText: defaultText,
 			initiatedByFrame: frame,
 			completionHandler: completionHandler
-		)
+		) == nil {
+			completionHandler(nil)
+		}
 	}
 
-	open func webView(_ webView: WKWebView, shouldPreviewElement elementInfo: WKPreviewElementInfo) -> Bool {
+	public func webView(_ webView: WKWebView, shouldPreviewElement elementInfo: WKPreviewElementInfo) -> Bool {
 		wkUIDelegate?.webView?(webView, shouldPreviewElement: elementInfo) ?? false
 	}
 
-	open func webView(
+	public func webView(
 		_ webView: WKWebView,
 		previewingViewControllerForElement elementInfo: WKPreviewElementInfo,
 		defaultActions previewActions: [WKPreviewActionItem]
 	) -> UIViewController? {
-		wkUIDelegate?.webView?(webView, previewingViewControllerForElement: elementInfo, defaultActions: previewActions)
+		return wkUIDelegate?.webView?(webView, previewingViewControllerForElement: elementInfo, defaultActions: previewActions)
 	}
 
-	open func webView(_ webView: WKWebView, commitPreviewingViewController previewingViewController: UIViewController) {
+	public func webView(_ webView: WKWebView, commitPreviewingViewController previewingViewController: UIViewController) {
 		wkUIDelegate?.webView?(webView, commitPreviewingViewController: previewingViewController)
 	}
 
 	@available(iOS 13.0, *)
-	open func webView(
+	public func webView(
 		_ webView: WKWebView,
 		contextMenuConfigurationForElement elementInfo: WKContextMenuElementInfo,
 		completionHandler: @escaping (UIContextMenuConfiguration?) -> Void
 	) {
-		wkUIDelegate?.webView?(webView, contextMenuConfigurationForElement: elementInfo, completionHandler: completionHandler)
+		if wkUIDelegate?.webView?(webView, contextMenuConfigurationForElement: elementInfo, completionHandler: completionHandler) == nil {
+			completionHandler(nil)
+		}
 	}
 
 	@available(iOS 13.0, *)
-	open func webView(_ webView: WKWebView, contextMenuWillPresentForElement elementInfo: WKContextMenuElementInfo) {
+	public func webView(_ webView: WKWebView, contextMenuWillPresentForElement elementInfo: WKContextMenuElementInfo) {
 		wkUIDelegate?.webView?(webView, contextMenuWillPresentForElement: elementInfo)
 	}
 
 	@available(iOS 13.0, *)
-	open func webView(
+	public func webView(
 		_ webView: WKWebView,
 		contextMenuForElement elementInfo: WKContextMenuElementInfo,
 		willCommitWithAnimator animator: UIContextMenuInteractionCommitAnimating
@@ -182,7 +205,7 @@ extension VirtusizeWebView: WKUIDelegate {
 	}
 
 	@available(iOS 13.0, *)
-	open func webView(_ webView: WKWebView, contextMenuDidEndForElement elementInfo: WKContextMenuElementInfo) {
+	public func webView(_ webView: WKWebView, contextMenuDidEndForElement elementInfo: WKContextMenuElementInfo) {
 		wkUIDelegate?.webView?(webView, contextMenuDidEndForElement: elementInfo)
 	}
 
@@ -194,5 +217,122 @@ extension VirtusizeWebView: WKUIDelegate {
 	/// Checks if a URL is a link from SNS authentication
 	private func isLinkFromSNSAuth(url: String?) -> Bool {
 		return url != nil && (url!.contains("facebook") || url!.contains("google")) && url!.contains("oauth")
+	}
+}
+
+extension VirtusizeWebView: WKNavigationDelegate {
+
+	public func webView(
+		_ webView: WKWebView,
+		decidePolicyFor navigationAction: WKNavigationAction,
+		decisionHandler: @escaping (WKNavigationActionPolicy) -> Swift.Void
+	) {
+		if wkNavigationDelegate?.webView?(webView, decidePolicyFor: navigationAction, decisionHandler: decisionHandler) == nil {
+			decisionHandler(.allow)
+		}
+	}
+
+	@available(iOS 13.0, *)
+	public func webView(
+		_ webView: WKWebView,
+		decidePolicyFor navigationAction: WKNavigationAction,
+		preferences: WKWebpagePreferences,
+		decisionHandler: @escaping (WKNavigationActionPolicy, WKWebpagePreferences) -> Void
+	) {
+		if wkNavigationDelegate?.webView?(
+			webView,
+			decidePolicyFor: navigationAction,
+			preferences: preferences,
+			decisionHandler: decisionHandler
+		) == nil {
+			self.webView(webView, decidePolicyFor: navigationAction) { (policy) in
+				decisionHandler(policy, preferences)
+			}
+		}
+	}
+
+	public func webView(
+		_ webView: WKWebView,
+		decidePolicyFor navigationResponse: WKNavigationResponse,
+		decisionHandler: @escaping (WKNavigationResponsePolicy
+		) ->
+							Swift.Void) {
+		if wkNavigationDelegate?.webView?(webView, decidePolicyFor: navigationResponse, decisionHandler: decisionHandler) == nil {
+			decisionHandler(.allow)
+		}
+	}
+
+	public func webView(_ webView: WKWebView, didStartProvisionalNavigation navigation: WKNavigation!) {
+		wkNavigationDelegate?.webView?(webView, didStartProvisionalNavigation: navigation)
+	}
+
+	public func webView(_ webView: WKWebView, didReceiveServerRedirectForProvisionalNavigation navigation: WKNavigation!) {
+		wkNavigationDelegate?.webView?(webView, didReceiveServerRedirectForProvisionalNavigation: navigation)
+	}
+
+	public func webView(
+		_ webView: WKWebView,
+		didFailProvisionalNavigation navigation: WKNavigation!,
+		withError error: Error
+	) {
+		wkNavigationDelegate?.webView?(webView, didFailProvisionalNavigation: navigation, withError: error)
+	}
+
+	public func webView(_ webView: WKWebView, didCommit navigation: WKNavigation!) {
+		wkNavigationDelegate?.webView?(webView, didCommit: navigation)
+	}
+
+	public func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
+		evaluateJavaScript("window.virtusizeSNSEnabled = true;", completionHandler: nil)
+		wkNavigationDelegate?.webView?(webView, didFinish: navigation)
+	}
+
+	public func webView(_ webView: WKWebView, didFail navigation: WKNavigation!, withError error: Error) {
+		wkNavigationDelegate?.webView?(webView, didFail: navigation, withError: error)
+	}
+
+	public func webView(
+		_ webView: WKWebView,
+		didReceive challenge: URLAuthenticationChallenge,
+		completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Swift.Void
+	) {
+		guard wkNavigationDelegate?.webView?(
+				webView,
+				didReceive: challenge,
+				completionHandler: completionHandler
+		) != nil else {
+			completionHandler(.rejectProtectionSpace, nil)
+			return
+		}
+	}
+
+	public func webViewWebContentProcessDidTerminate(_ webView: WKWebView) {
+		wkNavigationDelegate?.webViewWebContentProcessDidTerminate?(webView)
+	}
+
+	@available(iOS 14.0, *)
+	public func webView(
+		_ webView: WKWebView,
+		authenticationChallenge challenge: URLAuthenticationChallenge,
+		shouldAllowDeprecatedTLS decisionHandler: @escaping (Bool) -> Void
+	) {
+		if wkNavigationDelegate?.webView?(
+			webView,
+			authenticationChallenge: challenge,
+			shouldAllowDeprecatedTLS: decisionHandler
+		) == nil {
+			decisionHandler(false)
+			return
+		}
+	}
+
+	@available(iOS 14.5, *)
+	public func webView(_ webView: WKWebView, navigationAction: WKNavigationAction, didBecome download: WKDownload) {
+		wkNavigationDelegate?.webView?(webView, navigationAction: navigationAction, didBecome: download)
+	}
+
+	@available(iOS 14.5, *)
+	public func webView(_ webView: WKWebView, navigationResponse: WKNavigationResponse, didBecome download: WKDownload) {
+		wkNavigationDelegate?.webView?(webView, navigationResponse: navigationResponse, didBecome: download)
 	}
 }


### PR DESCRIPTION
## Summary
The SNS buttons are hidden by default when Aoyama is loaded in a web view.
To enable these buttons, the webview executes `window.virtusizeSNSEnabled = true;` when the webpage has finished loading.

**Before**
<img width="322" alt="Screen Shot 2021-07-09 at 10 57 51" src="https://user-images.githubusercontent.com/7802052/125012082-88d74600-e0a4-11eb-96cc-66a4fbde3c47.png">

**After**
<img width="321" alt="Screen Shot 2021-07-09 at 10 58 36" src="https://user-images.githubusercontent.com/7802052/125012135-a3a9ba80-e0a4-11eb-8440-d1722f7b4e62.png">
