### PR TITLE
Feature: Setup GitHub Actions and create a PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,15 @@
+### Description
+
+_Describe why we made this change and what was changed_
+
+### Demo
+
+_Add relevant screenshots or demo GIFs_
+
+| Before | After |
+| --- | --- |
+| *img or gif* | *img or gif* |
+
+### Ticket
+
+_Ticket link, if applicable_

--- a/.github/workflows/pull-request-checks.yml
+++ b/.github/workflows/pull-request-checks.yml
@@ -4,7 +4,7 @@ on: [pull_request]
 
 jobs:
   build:
-    runs-on: macOS-latest
+    runs-on: macos-latest
     steps:
       - name: Check out code
         uses: actions/checkout@v2
@@ -14,7 +14,7 @@ jobs:
         run: make build
 
   lint:
-    runs-on: macOS-latest
+    runs-on: macos-latest
     steps:
       - name: Check out code
         uses: actions/checkout@v2
@@ -24,7 +24,7 @@ jobs:
         run: pod lib lint --allow-warnings
 
   test:
-    runs-on: macOS-latest
+    runs-on: macos-latest
     steps:
       - name: Check out code
         uses: actions/checkout@v2

--- a/.github/workflows/pull-request-checks.yml
+++ b/.github/workflows/pull-request-checks.yml
@@ -7,8 +7,6 @@ jobs:
     runs-on: macOS-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Install Dependencies
-        run: pod install --repo-update
       - name: Build the project
         run: make build
       - name: Swift Lint

--- a/.github/workflows/pull-request-checks.yml
+++ b/.github/workflows/pull-request-checks.yml
@@ -1,0 +1,21 @@
+name: Pull request CI checks
+
+on: [pull_request]
+
+build:
+    runs-on: macOS-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install Dependencies
+      run:
+        pod install --repo-update
+	- name: Build the project
+      run:
+        make build
+    - name: Swift Lint
+      run: swiftlint
+    - name: Run Tests
+      run:
+		make test
+    - name: Pod Lint
+      run: pod lib lint --allow-warnings

--- a/.github/workflows/pull-request-checks.yml
+++ b/.github/workflows/pull-request-checks.yml
@@ -5,17 +5,14 @@ on: [pull_request]
 build:
     runs-on: macOS-latest
     steps:
-    - uses: actions/checkout@v2
-    - name: Install Dependencies
-      run:
-        pod install --repo-update
-	- name: Build the project
-      run:
-        make build
-    - name: Swift Lint
-      run: swiftlint
-    - name: Run Tests
-      run:
-		make test
-    - name: Pod Lint
-      run: pod lib lint --allow-warnings
+      - uses: actions/checkout@v2
+      - name: Install Dependencies
+        run: pod install --repo-update
+      - name: Build the project
+        run: make build
+      - name: Swift Lint
+        run: swiftlint
+      - name: Run Tests
+        run: make test
+      - name: Pod Lint
+        run: pod lib lint --allow-warnings

--- a/.github/workflows/pull-request-checks.yml
+++ b/.github/workflows/pull-request-checks.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@v2
       - name: Swift Lint
         run: swiftlint
-	  - name: Pod Lint
+      - name: Pod Lint
         run: pod lib lint --allow-warnings
 
   test:

--- a/.github/workflows/pull-request-checks.yml
+++ b/.github/workflows/pull-request-checks.yml
@@ -6,12 +6,27 @@ jobs:
   build:
     runs-on: macOS-latest
     steps:
-      - uses: actions/checkout@v2
-      - name: Build the project
+      - name: Check out code
+        uses: actions/checkout@v2
+      - name: Clean build directory
+        run: make clean
+      - name: Execute build
         run: make build
+
+  lint:
+    runs-on: macOS-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
       - name: Swift Lint
         run: swiftlint
+	  - name: Pod Lint
+        run: pod lib lint --allow-warnings
+
+  test:
+    runs-on: macOS-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
       - name: Run Tests
         run: make test
-      - name: Pod Lint
-        run: pod lib lint --allow-warnings

--- a/.github/workflows/pull-request-checks.yml
+++ b/.github/workflows/pull-request-checks.yml
@@ -2,7 +2,8 @@ name: Pull request CI checks
 
 on: [pull_request]
 
-build:
+jobs:
+  build:
     runs-on: macOS-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,28 @@
+name: Release
+
+on:
+  release:
+    types: [released]
+
+jobs:
+  build:
+    runs-on: macOS-latest
+    
+    steps:
+    - name: Check out code
+      uses: actions/checkout@v2
+
+    - name: Install Cocoapods
+      run: gem install cocoapods
+
+    - name: Pod validation
+      run: |
+        set -e -o pipefail
+        pod lib lint --allow-warnings
+        pod spec lint --allow-warnings
+
+    - name: Push to CocoaPods
+      run: |
+        pod trunk push --allow-warnings
+      env:
+        COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}

--- a/Makefile
+++ b/Makefile
@@ -16,22 +16,21 @@ export HELP_MESSAGE
 
 build:
 
-	xcodebuild build \
-		-quiet \
-		-workspace "Virtusize.xcworkspace" \
-		-scheme "Virtusize" \
-		-destination "platform=iOS Simulator,name=iPhone 8,OS=14.4" \
-		clean build
-
-test:
-
-	xcodebuild build \
+	xcodebuild clean build \
 		-quiet \
 		-workspace "Virtusize.xcworkspace" \
 		-scheme "Virtusize" \
 		-sdk "iphonesimulator" \
-		-destination "platform=iOS Simulator,name=iPhone 8,OS=14.4" \
-		clean build test
+		-destination "platform=iOS Simulator,name=iPhone 8,OS=latest"
+
+test:
+
+	xcodebuild clean test \
+		-quiet \
+		-workspace "Virtusize.xcworkspace" \
+		-scheme "Virtusize" \
+		-sdk "iphonesimulator" \
+		-destination "platform=iOS Simulator,name=iPhone 8,OS=latest"
 
 clean:
 

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ build:
 		-quiet \
 		-workspace "Virtusize.xcworkspace" \
 		-scheme "Virtusize" \
-		-destination "platform=iOS Simulator,name=iPhone 8,OS=13.5" \
+		-destination "platform=iOS Simulator,name=iPhone 8,OS=14.4" \
 		clean build
 
 test:
@@ -30,7 +30,7 @@ test:
 		-workspace "Virtusize.xcworkspace" \
 		-scheme "Virtusize" \
 		-sdk "iphonesimulator" \
-		-destination "platform=iOS Simulator,name=iPhone 8,OS=13.5" \
+		-destination "platform=iOS Simulator,name=iPhone 8,OS=14.4" \
 		clean build test
 
 clean:

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ test:
 	xcodebuild clean test \
 		-quiet \
 		-workspace "Virtusize.xcworkspace" \
-		-scheme "Virtusize" \
+		-scheme "VirtusizeTests" \
 		-sdk "iphonesimulator" \
 		-destination "platform=iOS Simulator,name=iPhone 8,OS=latest"
 

--- a/Makefile
+++ b/Makefile
@@ -16,13 +16,22 @@ export HELP_MESSAGE
 
 build:
 
-	xcodebuild -workspace Virtusize.xcworkspace -scheme Virtusize -destination 'platform=iOS Simulator,name=iPhone 8,OS=13.5' clean build
-
+	xcodebuild build \
+		-quiet \
+		-workspace "Virtusize.xcworkspace" \
+		-scheme "Virtusize" \
+		-destination "platform=iOS Simulator,name=iPhone 8,OS=13.5" \
+		clean build
 
 test:
 
-	xcodebuild -workspace Virtusize.xcworkspace -scheme Virtusize -destination 'platform=iOS Simulator,name=iPhone 8,OS=13.5' clean build test
-
+	xcodebuild build \
+		-quiet \
+		-workspace "Virtusize.xcworkspace" \
+		-scheme "Virtusize" \
+		-sdk "iphonesimulator" \
+		-destination "platform=iOS Simulator,name=iPhone 8,OS=13.5" \
+		clean build test
 
 clean:
 

--- a/README-JP.md
+++ b/README-JP.md
@@ -54,7 +54,7 @@ You need a unique API key and an Admin account, only available to Virtusize cust
 ## 対応バージョン
 
 - iOS 10.3+
-- Xcode 11+
+- Xcode 12+
 - Swift 5.0+
 
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ You need a unique API key and an Admin account, only available to Virtusize cust
 ## Requirements
 
 - iOS 10.3+
-- Xcode 11+
+- Xcode 12+
 - Swift 5.0+
 
 

--- a/Virtusize.xcodeproj/project.pbxproj
+++ b/Virtusize.xcodeproj/project.pbxproj
@@ -1039,7 +1039,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = Virtusize/Tests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.3;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.virtusize.VirtusizeTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -1058,7 +1058,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = Z57T9D7E3B;
 				INFOPLIST_FILE = Virtusize/Tests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.3;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.virtusize.VirtusizeTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/Virtusize.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/Virtusize.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/Virtusize.xcodeproj/xcshareddata/xcschemes/Virtusize.xcscheme
+++ b/Virtusize.xcodeproj/xcshareddata/xcschemes/Virtusize.xcscheme
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1250"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "4DED8D1B205755C3001CA7DF"
+               BuildableName = "Virtusize.framework"
+               BlueprintName = "Virtusize"
+               ReferencedContainer = "container:Virtusize.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "4DED8D1B205755C3001CA7DF"
+            BuildableName = "Virtusize.framework"
+            BlueprintName = "Virtusize"
+            ReferencedContainer = "container:Virtusize.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Virtusize.xcodeproj/xcshareddata/xcschemes/VirtusizeTests.xcscheme
+++ b/Virtusize.xcodeproj/xcshareddata/xcschemes/VirtusizeTests.xcscheme
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1250"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "4DED8D24205755C3001CA7DF"
+               BuildableName = "VirtusizeTests.xctest"
+               BlueprintName = "VirtusizeTests"
+               ReferencedContainer = "container:Virtusize.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "4DED8D24205755C3001CA7DF"
+               BuildableName = "VirtusizeTests.xctest"
+               BlueprintName = "VirtusizeTests"
+               ReferencedContainer = "container:Virtusize.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "4DED8D24205755C3001CA7DF"
+            BuildableName = "VirtusizeTests.xctest"
+            BlueprintName = "VirtusizeTests"
+            ReferencedContainer = "container:Virtusize.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Virtusize/Sources/VirtusizeWebView.swift
+++ b/Virtusize/Sources/VirtusizeWebView.swift
@@ -353,23 +353,13 @@ extension VirtusizeWebView: WKNavigationDelegate {
 		authenticationChallenge challenge: URLAuthenticationChallenge,
 		shouldAllowDeprecatedTLS decisionHandler: @escaping (Bool) -> Void
 	) {
-		if wkNavigationDelegate?.webView?(
+		guard wkNavigationDelegate?.webView?(
 			webView,
 			authenticationChallenge: challenge,
 			shouldAllowDeprecatedTLS: decisionHandler
-		) == nil {
+		) != nil else {
 			decisionHandler(false)
 			return
 		}
-	}
-
-	@available(iOS 14.5, *)
-	public func webView(_ webView: WKWebView, navigationAction: WKNavigationAction, didBecome download: WKDownload) {
-		wkNavigationDelegate?.webView?(webView, navigationAction: navigationAction, didBecome: download)
-	}
-
-	@available(iOS 14.5, *)
-	public func webView(_ webView: WKWebView, navigationResponse: WKNavigationResponse, didBecome download: WKDownload) {
-		wkNavigationDelegate?.webView?(webView, navigationResponse: navigationResponse, didBecome: download)
 	}
 }

--- a/Virtusize/Tests/APIEventTests.swift
+++ b/Virtusize/Tests/APIEventTests.swift
@@ -52,8 +52,8 @@ class APIEventTests: XCTestCase {
                        UIDevice.current.orientation.isLandscape ? "landscape" : "portrait"
         )
         XCTAssertEqual(payloadJson?["browserResolution"], "\(Int(screenSize.height))x\(Int(screenSize.width))")
-        XCTAssertEqual(payloadJson?["integrationVersion"], "2.3.1")
-        XCTAssertEqual(payloadJson?["snippetVersion"], "2.3.1")
+        XCTAssertEqual(payloadJson?["integrationVersion"], "2.3.2")
+        XCTAssertEqual(payloadJson?["snippetVersion"], "2.3.2")
     }
 
     func testAPIEvent_alignProductDataCheckContext_hasExpectedPayload() {


### PR DESCRIPTION
### Description

1. Create `.github/workflows/pull-request-checks.yml` to run lint checks and tests triggered by pull requests.
2. Create `.github/workflows/release.yml` to deploy the SDK to CocoaPods triggered by Github releases
3. Create `.github/pull_request_template.md` for the pull request template 
4. Update README for the requirement of the Xcode version from 11.0+ to 12.0+. 
Tried to run `make build` on the Github actions virtual environment with Xcode 11.2.1 (/Applications/Xcode_11.2.1.app/Contents/Developer) and it had an error shown as follows because this function of the WKWebview is only available for iOS 14.0+ and only Xcode 12+ supports iOS 14+

<img width="949" alt="Screen Shot 2021-09-15 at 11 08 20" src="https://user-images.githubusercontent.com/7802052/133358739-57ec86b1-708a-45e3-8a48-75df2097e178.png">

[Ref for Xcode vs. iOS versions](https://github.com/actions/virtual-environments/blob/main/images/macos/macos-10.15-Readme.md#installed-sdks)

### Ticket

https://app.clickup.com/t/a84w95