### PR TITLE
Hotfix/2.4.3

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,7 @@ jobs:
     - name: Push VirtusizeCore to CocoaPods
       run: |
         pod trunk push VirtusizeCore.podspec --allow-warnings
+        pod repo update
 
     - name: Pod Validation for Virtusize
       run: |
@@ -37,3 +38,4 @@ jobs:
     - name: Push Virtusize to CocoaPods
       run: |
         pod trunk push Virtusize.podspec --allow-warnings
+        pod repo update

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,7 +13,11 @@ Use list notation, and following prefixes:
 
 ## NEXT RELEASE for Version 2.x.x
 
-### 2.4.2
+### 2.4.3
+
+- Bugfix: Fix errors when running `pod spec lint`
+
+### 2.4.2 (Invalid)
 
 - Feature: Release the `VirtusizeCore` module
 

--- a/Example/Sources/ViewController.swift
+++ b/Example/Sources/ViewController.swift
@@ -25,9 +25,6 @@
 import UIKit
 import WebKit
 import Virtusize
-#if SWIFT_PACKAGE
-import VirtusizeCore
-#endif
 
 class ViewController: UIViewController {
 

--- a/README-JP.md
+++ b/README-JP.md
@@ -80,7 +80,7 @@ platform :ios, '10.3'
 use_frameworks!
 
 target '<your-target-name>' do
-pod 'Virtusize', '~> 2.4.2'
+pod 'Virtusize', '~> 2.4.3'
 end
 ```
 
@@ -97,7 +97,7 @@ $ pod install
 Starting with the  `2.3.1` release, Virtusize supports installation via [Swift Package Manager](https://swift.org/package-manager/)
 
 1. In Xcode, select **File** > **Swift Packages** > **Add Package Dependency...** and enter `https://github.com/virtusize/integration_ios.git` as the repository URL.
-2. Select a minimum version of `2.4.2`
+2. Select a minimum version of `2.4.3`
 3. Click **Next**
 
 

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ platform :ios, '10.3'
 use_frameworks!
 
 target '<your-target-name>' do
-pod 'Virtusize', '~> 2.4.2'
+pod 'Virtusize', '~> 2.4.3'
 end
 ```
 
@@ -97,7 +97,7 @@ $ pod install
 Starting with the  `2.3.1` release, Virtusize supports installation via [Swift Package Manager](https://swift.org/package-manager/)
 
 1. In Xcode, select **File** > **Swift Packages** > **Add Package Dependency...** and enter `https://github.com/virtusize/integration_ios.git` as the repository URL.
-2. Select a minimum version of `2.4.2`
+2. Select a minimum version of `2.4.3`
 3. Click **Next**
 
 

--- a/Virtusize.podspec
+++ b/Virtusize.podspec
@@ -15,5 +15,5 @@ Pod::Spec.new do |s|
   s.source_files = ["Virtusize/Sources/*.{swift, h}", "Virtusize/Sources/**/*.swift"]
   s.resources = "Virtusize/Sources/Resources/**/*.otf"
   s.resource_bundle = { 'Virtusize' => ["Virtusize/Sources/Resources/**/*.lproj", "Virtusize/Sources/VirtusizeAssets.xcassets"] }
-  s.dependency "VirtusizeCore", "#{s.version}"
+  s.dependency "VirtusizeCore", "<= #{s.version}"
 end

--- a/Virtusize.podspec
+++ b/Virtusize.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name = 'Virtusize'
-  s.version = '2.4.2'
+  s.version = '2.4.3'
   s.license = { :type => 'MIT', :file => 'LICENSE' }
   s.summary = 'Integrate Virtusize on iOS devices'
   s.homepage = 'https://www.virtusize.com/'

--- a/Virtusize/Sources/Flutter/VirtusizeFlutterReposiory.swift
+++ b/Virtusize/Sources/Flutter/VirtusizeFlutterReposiory.swift
@@ -23,9 +23,7 @@
 //
 
 import Foundation
-#if SWIFT_PACKAGE
 import VirtusizeCore
-#endif
 
 public class VirtusizeFlutterRepository: NSObject {
 	public static let shared: VirtusizeFlutterRepository = {

--- a/Virtusize/Sources/Internal/API/APIEvent.swift
+++ b/Virtusize/Sources/Internal/API/APIEvent.swift
@@ -24,9 +24,7 @@
 
 import UIKit
 import Foundation
-#if SWIFT_PACKAGE
 import VirtusizeCore
-#endif
 
 typealias Payload = JSONObject
 

--- a/Virtusize/Sources/Internal/API/VirtusizeAPIRequest.swift
+++ b/Virtusize/Sources/Internal/API/VirtusizeAPIRequest.swift
@@ -23,9 +23,7 @@
 //
 
 import Foundation
-#if SWIFT_PACKAGE
 import VirtusizeCore
-#endif
 
 extension APIRequest {
 	/// Gets the `URLRequest` for the `productCheck` request

--- a/Virtusize/Sources/Internal/API/VirtusizeAPIService.swift
+++ b/Virtusize/Sources/Internal/API/VirtusizeAPIService.swift
@@ -24,9 +24,7 @@
 
 import UIKit
 import Foundation
-#if SWIFT_PACKAGE
 import VirtusizeCore
-#endif
 
 /// This class is to handle API requests to the Virtusize server
 class VirtusizeAPIService: APIService {

--- a/Virtusize/Sources/Internal/Utils/Image+Extensions.swift
+++ b/Virtusize/Sources/Internal/Utils/Image+Extensions.swift
@@ -24,9 +24,7 @@
 //
 
 import UIKit
-#if SWIFT_PACKAGE
 import VirtusizeCore
-#endif
 
 internal extension UIImage {
 

--- a/Virtusize/Sources/Internal/Utils/Localization.swift
+++ b/Virtusize/Sources/Internal/Utils/Localization.swift
@@ -23,9 +23,7 @@
 //
 
 import Foundation
-#if SWIFT_PACKAGE
 import VirtusizeCore
-#endif
 
 /// This class is used to localize texts in the SDK
 internal class Localization {

--- a/Virtusize/Sources/Internal/Utils/VirtusizeBundleLoader.swift
+++ b/Virtusize/Sources/Internal/Utils/VirtusizeBundleLoader.swift
@@ -24,9 +24,7 @@
 //
 
 import Foundation
-#if SWIFT_PACKAGE
 import VirtusizeCore
-#endif
 
 public class VirtusizeBundleLoader: BundleLoaderProtocol {
 	public static let bundleClass: AnyClass = VirtusizeBundleLoader.self

--- a/Virtusize/Sources/Internal/Workers/Deserializer.swift
+++ b/Virtusize/Sources/Internal/Workers/Deserializer.swift
@@ -23,9 +23,7 @@
 //
 
 import Foundation
-#if SWIFT_PACKAGE
 import VirtusizeCore
-#endif
 
 /// A structure that helps to deserialize the models specific to the Virtusize API
 internal struct Deserializer {

--- a/Virtusize/Sources/Models/VirtusizeParams.swift
+++ b/Virtusize/Sources/Models/VirtusizeParams.swift
@@ -22,9 +22,7 @@
 //  THE SOFTWARE.
 //
 
-#if SWIFT_PACKAGE
 import VirtusizeCore
-#endif
 
 /// The class that wraps the parameters we can pass to the Virtusize web app
 public class VirtusizeParams {

--- a/Virtusize/Sources/Models/VirtusizeProduct.swift
+++ b/Virtusize/Sources/Models/VirtusizeProduct.swift
@@ -23,9 +23,7 @@
 //
 
 import Foundation
-#if SWIFT_PACKAGE
 import VirtusizeCore
-#endif
 
 /// This structure represents a product in the Virtusize SDK
 public class VirtusizeProduct: Codable {

--- a/Virtusize/Sources/UI/VirtusizeWebViewController.swift
+++ b/Virtusize/Sources/UI/VirtusizeWebViewController.swift
@@ -24,9 +24,7 @@
 
 import UIKit
 import WebKit
-#if SWIFT_PACKAGE
 @_exported import VirtusizeCore
-#endif
 
 /// The methods of this protocol notify you with Virtusize specific messages such as errors as
 /// `VirtusizeError` and events as `VirtusizeEvent`

--- a/Virtusize/Sources/Virtusize.swift
+++ b/Virtusize/Sources/Virtusize.swift
@@ -23,9 +23,7 @@
 //
 
 import WebKit
-#if SWIFT_PACKAGE
 import VirtusizeCore
-#endif
 
 /// The main class used by Virtusize clients to perform all available operations related to fit check
 public class Virtusize {

--- a/Virtusize/Sources/VirtusizeConfiguration.swift
+++ b/Virtusize/Sources/VirtusizeConfiguration.swift
@@ -25,5 +25,5 @@
 import Foundation
 
 struct VirtusizeConfiguration {
-	static let SDKVersion = "2.4.2"
+	static let SDKVersion = "2.4.3"
 }

--- a/Virtusize/Sources/VirtusizeRepository.swift
+++ b/Virtusize/Sources/VirtusizeRepository.swift
@@ -23,9 +23,7 @@
 //
 
 import Foundation
-#if SWIFT_PACKAGE
 import VirtusizeCore
-#endif
 
 /// This class is used to handle the logic required to access remote and local data sources
 internal class VirtusizeRepository: NSObject {

--- a/Virtusize/Tests/APIEventTests.swift
+++ b/Virtusize/Tests/APIEventTests.swift
@@ -52,8 +52,8 @@ class APIEventTests: XCTestCase {
                        UIDevice.current.orientation.isLandscape ? "landscape" : "portrait"
         )
         XCTAssertEqual(payloadJson?["browserResolution"], "\(Int(screenSize.height))x\(Int(screenSize.width))")
-        XCTAssertEqual(payloadJson?["integrationVersion"], "2.4.2")
-        XCTAssertEqual(payloadJson?["snippetVersion"], "2.4.2")
+        XCTAssertEqual(payloadJson?["integrationVersion"], "2.4.3")
+        XCTAssertEqual(payloadJson?["snippetVersion"], "2.4.3")
     }
 
     func testAPIEvent_alignProductDataCheckContext_hasExpectedPayload() {

--- a/VirtusizeCore.podspec
+++ b/VirtusizeCore.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name = 'VirtusizeCore'
-  s.version = '2.4.2'
+  s.version = '2.4.3'
   s.license = { :type => 'MIT', :file => 'LICENSE' }
   s.summary = 'Virtusize Core for iOS'
   s.homepage = 'https://www.virtusize.com/'


### PR DESCRIPTION
### Description

- [x] Make sure to update trunk repo by running `pod repo update` once a Pod is published
- [x] Fix the code in VirtusizeCore is not found
The screenshot of this issue:
![Screen Shot 2021-11-16 at 13 12 53](https://user-images.githubusercontent.com/7802052/141916814-3804362a-73d6-4e76-9f37-e1a90bc835df.png)
- [x] Bump version to 2.4.3