### PR TITLE
Update size recommendation endpoints in iOS SDK

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,7 +16,10 @@ Use list notation, and following prefixes:
 - Refactor: Change the get-size endpoint from https://services.virtusize.jp/ds-functions/size-rec/get-size ➝ https://size-recommendation.virtusize.jp/item
 - Refactor: Change in request body of VirtusizeGetSizeParams: Remove "modelInfo" key,  in "gender" now getting value from VirtusizeUserBodyProfile
 - Refactor: Change in response Model of BodyProfileRecommendedSize
+- Refactor: VirtusizeEnvironment enum cases key set to Uppercase 
+- Cleanup: Remove Print functions and unnecessary commented code from BodyProfileRecommendedSize, VirtusizeAPIService, VirtusizeAPIRequest
 - Docs: Update Readme file to update pod version 
+
 
 
 ### 2.5.4

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,7 +15,7 @@ Use list notation, and following prefixes:
 ### 2.5.7
 - Refactor: Change the get-size endpoint from https://services.virtusize.jp/ds-functions/size-rec/get-size ➝ https://size-recommendation.virtusize.jp/item
 - Refactor: Change in request body of VirtusizeGetSizeParams: Remove "modelInfo" key,  in "gender" now getting value from VirtusizeUserBodyProfile
-- Refactor: Change in Responce Model of BodyProfileRecommendedSize
+- Refactor: Change in response Model of BodyProfileRecommendedSize
 - Docs: Update Readme file to update pod version 
 
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,13 @@ Use list notation, and following prefixes:
 
 
 ## NEXT RELEASE for Version 2.x.x
+### 2.5.7
+- Refactor: Change the get-size endpoint from https://services.virtusize.jp/ds-functions/size-rec/get-size ➝ https://size-recommendation.virtusize.jp/item
+- Refactor: Change in request body of VirtusizeGetSizeParams: Remove "modelInfo" key,  in "gender" now getting value from VirtusizeUserBodyProfile
+- Refactor: Change in Responce Model of BodyProfileRecommendedSize
+- Docs: Update Readme file to update pod version 
+
+
 ### 2.5.4
 - Refactor/Bugfix: Change VirtusizeAuth class name to VirtusizeAuthorization to resolve nested Class archive run time issue
 - Cleanup: Update deployment target to 13

--- a/Example/Sources/AppDelegate.swift
+++ b/Example/Sources/AppDelegate.swift
@@ -37,7 +37,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 		Virtusize.APIKey = "15cc36e1d7dad62b8e11722ce1a245cb6c5e6692"
 		// For using the Order API, Virtusize.userID is required
 		Virtusize.userID = "123"
-		// By default, the Virtusize environment will be set to .global
+		// By default, the Virtusize environment will be set to .JAPAN
 		Virtusize.environment = .JAPAN
 		Virtusize.params = VirtusizeParamsBuilder()
 			// By default, the initial language will be set based on the Virtusize environment

--- a/Example/Sources/AppDelegate.swift
+++ b/Example/Sources/AppDelegate.swift
@@ -38,10 +38,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 		// For using the Order API, Virtusize.userID is required
 		Virtusize.userID = "123"
 		// By default, the Virtusize environment will be set to .global
-		Virtusize.environment = .staging
+		Virtusize.environment = .japan
 		Virtusize.params = VirtusizeParamsBuilder()
 			// By default, the initial language will be set based on the Virtusize environment
-			.setLanguage(.JAPANESE)
+			.setLanguage(.ENGLISH)
 			// By default, ShowSGI is false
 			.setShowSGI(true)
 			// By default, Virtusize allows all the possible languages including English, Japanese and Korean

--- a/Example/Sources/AppDelegate.swift
+++ b/Example/Sources/AppDelegate.swift
@@ -38,7 +38,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 		// For using the Order API, Virtusize.userID is required
 		Virtusize.userID = "123"
 		// By default, the Virtusize environment will be set to .global
-		Virtusize.environment = .japan
+		Virtusize.environment = .JAPAN
 		Virtusize.params = VirtusizeParamsBuilder()
 			// By default, the initial language will be set based on the Virtusize environment
 			.setLanguage(.ENGLISH)

--- a/README-JP.md
+++ b/README-JP.md
@@ -138,7 +138,7 @@ func application(_ application: UIApplication, didFinishLaunchingWithOptions lau
     Virtusize.APIKey = "15cc36e1d7dad62b8e11722ce1a245cb6c5e6692"
     // For using the Order API, Virtusize.userID is required
     Virtusize.userID = "123"
-    // By default, the Virtusize environment will be set to .global
+    // By default, the Virtusize environment will be set to .GLOBAL
     Virtusize.environment = .STAGING
     Virtusize.params = VirtusizeParamsBuilder()
         // By default, the initial language will be set based on the Virtusize environment
@@ -156,7 +156,7 @@ func application(_ application: UIApplication, didFinishLaunchingWithOptions lau
 }
 ```
 
-環境は、実装をしている環境を選択してください `.staging`,  `.global`, `.japan` ,もしくは`.korea`から選択できます。
+環境は、実装をしている環境を選択してください `.STAGING`,  `.GLOBAL`, `.JAPAN` ,もしくは`.KOREA`から選択できます。
 
 **VirtusizeParamsBuilder**を使用して実装構成を変更することにより、`Virtusize.params`をセットアップできます。可能な構成方法を次の表に示します。
 

--- a/README-JP.md
+++ b/README-JP.md
@@ -139,7 +139,7 @@ func application(_ application: UIApplication, didFinishLaunchingWithOptions lau
     // For using the Order API, Virtusize.userID is required
     Virtusize.userID = "123"
     // By default, the Virtusize environment will be set to .global
-    Virtusize.environment = .staging
+    Virtusize.environment = .STAGING
     Virtusize.params = VirtusizeParamsBuilder()
         // By default, the initial language will be set based on the Virtusize environment
         .setLanguage(.JAPANESE)

--- a/README-JP.md
+++ b/README-JP.md
@@ -80,7 +80,7 @@ platform :ios, '13.0'
 use_frameworks!
 
 target '<your-target-name>' do
-pod 'Virtusize', '~> 2.5.4'
+pod 'Virtusize', '~> 2.5.7'
 end
 ```
 
@@ -97,7 +97,7 @@ $ pod install
 Starting with the  `2.3.1` release, Virtusize supports installation via [Swift Package Manager](https://swift.org/package-manager/)
 
 1. In Xcode, select **File** > **Swift Packages** > **Add Package Dependency...** and enter `https://github.com/virtusize/integration_ios.git` as the repository URL.
-2. Select a minimum version of `2.5.4`
+2. Select a minimum version of `2.5.7`
 3. Click **Next**
 
 

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ func application(_ application: UIApplication, didFinishLaunchingWithOptions lau
     // For using the Order API, Virtusize.userID is required
     Virtusize.userID = "123"
     // By default, the Virtusize environment will be set to .global
-    Virtusize.environment = .staging
+    Virtusize.environment = .STAGING
     Virtusize.params = VirtusizeParamsBuilder()
         // By default, the initial language will be set based on the Virtusize environment
         .setLanguage(.JAPANESE)

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ func application(_ application: UIApplication, didFinishLaunchingWithOptions lau
     Virtusize.APIKey = "15cc36e1d7dad62b8e11722ce1a245cb6c5e6692"
     // For using the Order API, Virtusize.userID is required
     Virtusize.userID = "123"
-    // By default, the Virtusize environment will be set to .global
+    // By default, the Virtusize environment will be set to .GLOBAL
     Virtusize.environment = .STAGING
     Virtusize.params = VirtusizeParamsBuilder()
         // By default, the initial language will be set based on the Virtusize environment
@@ -145,7 +145,7 @@ func application(_ application: UIApplication, didFinishLaunchingWithOptions lau
 }
 ```
 
-The environment is the region you are running the integration from, either `.staging`, `.global`, `.japan` or `.korea`
+The environment is the region you are running the integration from, either `.STAGING`, `.GLOBAL`, `.JAPAN` or `.korea`
 
 You can set up the `Virtusize.params` by using **VirtusizeParamsBuilder** to change the configuration of the integration. Possible configuration methods are shown in the following table:
 

--- a/Virtusize.podspec
+++ b/Virtusize.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name = 'Virtusize'
-  s.version = '2.5.6'
+  s.version = '2.5.7'
   s.license = { :type => 'MIT', :file => 'LICENSE' }
   s.summary = 'Integrate Virtusize on iOS devices'
   s.homepage = 'https://www.virtusize.com/'

--- a/Virtusize.xcodeproj/project.pbxproj
+++ b/Virtusize.xcodeproj/project.pbxproj
@@ -9,9 +9,9 @@
 /* Begin PBXBuildFile section */
 		4D6C5793205FB9BA00DA910E /* Virtusize.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D6C5792205FB9BA00DA910E /* Virtusize.swift */; };
 		4D6C579A205FCBE900DA910E /* VirtusizeAPIRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D6C5799205FCBE900DA910E /* VirtusizeAPIRequest.swift */; };
-		849CDF1F2ADD0572007FE499 /* VirtusizeAuth.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8478167E2AD6C50B009359F0 /* VirtusizeAuth.xcframework */; };
-		849CDF202ADD0572007FE499 /* VirtusizeAuth.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 8478167E2AD6C50B009359F0 /* VirtusizeAuth.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		849CDF242ADD465C007FE499 /* VirtusizeCore.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 849CDF232ADD465C007FE499 /* VirtusizeCore.xcframework */; };
+		8455FFD42B29A0C500019B1B /* VirtusizeGetSizeItemsParam.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8455FFD32B29A0C500019B1B /* VirtusizeGetSizeItemsParam.swift */; };
+		8455FFDC2B29D45A00019B1B /* VirtusizeCore.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8455FFDA2B29D45A00019B1B /* VirtusizeCore.xcframework */; };
+		8455FFDD2B29D45A00019B1B /* VirtusizeAuth.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8455FFDB2B29D45A00019B1B /* VirtusizeAuth.xcframework */; };
 		9C0EBA2225BACADD00F1D746 /* VirtusizeProductImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C0EBA2125BACADD00F1D746 /* VirtusizeProductImage.swift */; };
 		9C106EB024FCE0C70012EE51 /* VirtusizeInPageStandard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C106EAF24FCE0C70012EE51 /* VirtusizeInPageStandard.swift */; };
 		9C106EB424FE41EC0012EE51 /* VirtusizeProductImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C106EB324FE41EC0012EE51 /* VirtusizeProductImageView.swift */; };
@@ -128,7 +128,6 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				849CDF202ADD0572007FE499 /* VirtusizeAuth.xcframework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -140,8 +139,9 @@
 		4D6C5799205FCBE900DA910E /* VirtusizeAPIRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VirtusizeAPIRequest.swift; sourceTree = "<group>"; };
 		4DED8D1C205755C3001CA7DF /* Virtusize.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Virtusize.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		4DED8D25205755C3001CA7DF /* VirtusizeTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = VirtusizeTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
-		8478167E2AD6C50B009359F0 /* VirtusizeAuth.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = VirtusizeAuth.xcframework; path = Frameworks/VirtusizeAuth.xcframework; sourceTree = "<group>"; };
-		849CDF232ADD465C007FE499 /* VirtusizeCore.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = VirtusizeCore.xcframework; path = Frameworks/VirtusizeCore.xcframework; sourceTree = "<group>"; };
+		8455FFD32B29A0C500019B1B /* VirtusizeGetSizeItemsParam.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VirtusizeGetSizeItemsParam.swift; sourceTree = "<group>"; };
+		8455FFDA2B29D45A00019B1B /* VirtusizeCore.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; path = VirtusizeCore.xcframework; sourceTree = "<group>"; };
+		8455FFDB2B29D45A00019B1B /* VirtusizeAuth.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; path = VirtusizeAuth.xcframework; sourceTree = "<group>"; };
 		9C0EBA2125BACADD00F1D746 /* VirtusizeProductImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VirtusizeProductImage.swift; sourceTree = "<group>"; };
 		9C106EAF24FCE0C70012EE51 /* VirtusizeInPageStandard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VirtusizeInPageStandard.swift; sourceTree = "<group>"; };
 		9C106EB324FE41EC0012EE51 /* VirtusizeProductImageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VirtusizeProductImageView.swift; sourceTree = "<group>"; };
@@ -247,8 +247,8 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				849CDF1F2ADD0572007FE499 /* VirtusizeAuth.xcframework in Frameworks */,
-				849CDF242ADD465C007FE499 /* VirtusizeCore.xcframework in Frameworks */,
+				8455FFDC2B29D45A00019B1B /* VirtusizeCore.xcframework in Frameworks */,
+				8455FFDD2B29D45A00019B1B /* VirtusizeAuth.xcframework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -281,8 +281,8 @@
 				9CF77B9726CBBF7A0019889E /* Virtusize.podspec */,
 				4DED8D1E205755C3001CA7DF /* Sources */,
 				4DED8D29205755C3001CA7DF /* Tests */,
+				8455FFD92B29D45A00019B1B /* Frameworks */,
 				4DED8D1D205755C3001CA7DF /* Products */,
-				9CE6CA982744F9D600AAFF20 /* Frameworks */,
 				DFB2F0F1219BC40E00A69D1D /* CHANGES.md */,
 				9C4B38A026BBA84B00B73FE5 /* LICENSE */,
 				9CBDF5DD25AFFA0600E42012 /* README-JP.md */,
@@ -336,6 +336,15 @@
 				9CE7786A24B4121E00E4A127 /* Virtusize.h */,
 			);
 			name = "Supporting Files";
+			sourceTree = "<group>";
+		};
+		8455FFD92B29D45A00019B1B /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				8455FFDA2B29D45A00019B1B /* VirtusizeCore.xcframework */,
+				8455FFDB2B29D45A00019B1B /* VirtusizeAuth.xcframework */,
+			);
+			path = Frameworks;
 			sourceTree = "<group>";
 		};
 		9C01389026AE916A007F5392 /* Flutter */ = {
@@ -437,15 +446,6 @@
 			name = "JSON Test Files";
 			sourceTree = "<group>";
 		};
-		9CE6CA982744F9D600AAFF20 /* Frameworks */ = {
-			isa = PBXGroup;
-			children = (
-				849CDF232ADD465C007FE499 /* VirtusizeCore.xcframework */,
-				8478167E2AD6C50B009359F0 /* VirtusizeAuth.xcframework */,
-			);
-			name = Frameworks;
-			sourceTree = "<group>";
-		};
 		9CE7785624B3791E00E4A127 /* Utils */ = {
 			isa = PBXGroup;
 			children = (
@@ -486,6 +486,7 @@
 				9C6DDE2A24DCF2270021073A /* VirtusizeProductCheckData.swift */,
 				9C6DDE2D24DCF2A70021073A /* VirtusizeUserData.swift */,
 				9C1169332521F270006827B9 /* VirtusizeGetSizeParams.swift */,
+				8455FFD32B29A0C500019B1B /* VirtusizeGetSizeItemsParam.swift */,
 				9CEAB7AF24D930F000F969E1 /* VirtusizeBrandSizing.swift */,
 				9CEC8D8B252AB963001CBDFB /* ProductComparisonFitInfo.swift */,
 				9C4378D6253444F600E8729A /* UserSessionInfo.swift */,
@@ -748,6 +749,7 @@
 				9CEC8D99252B1986001CBDFB /* SizeComparisonRecommendedSize.swift in Sources */,
 				9C787FCD25DB7A3D00346F2A /* SizeRecommendationType.swift in Sources */,
 				9C58751C24EF7D2500352474 /* VirtusizeInPageMini.swift in Sources */,
+				8455FFD42B29A0C500019B1B /* VirtusizeGetSizeItemsParam.swift in Sources */,
 				9CEC8D852529CF58001CBDFB /* FindBestFitHelper.swift in Sources */,
 				9CEAB7BD24D943F400F969E1 /* VirtusizeServerProductMeta.swift in Sources */,
 				9C32A14B250279D00062C11D /* VirtusizeInPageView.swift in Sources */,

--- a/Virtusize/Sources/Flutter/VirtusizeFlutterReposiory.swift
+++ b/Virtusize/Sources/Flutter/VirtusizeFlutterReposiory.swift
@@ -139,7 +139,7 @@ public class VirtusizeFlutterRepository: NSObject {
 		productTypes: [VirtusizeProductType],
 		storeProduct: VirtusizeServerProduct,
 		userBodyProfile: VirtusizeUserBodyProfile
-	) -> BodyProfileRecommendedSize? {
+	) -> BodyProfileRecommendedSizeArray? {
 		let response = VirtusizeAPIService.getBodyProfileRecommendedSizeAsync(
 			productTypes: productTypes,
 			storeProduct: storeProduct,

--- a/Virtusize/Sources/Internal/API/APIEndpoints.swift
+++ b/Virtusize/Sources/Internal/API/APIEndpoints.swift
@@ -93,19 +93,22 @@ internal enum APIEndpoints {
 				components.path = "/a/api/v3/user-body-measurements"
 
 			case .getSize:
-				components.path =  "\(envPathForServicesAPI)/ds-functions/size-rec/get-size"
+				components.path =  "/item"
 
 			case .i18n(let langCode):
 				components.path = "/bundle-payloads/aoyama/\(langCode)"
 		}
+   
 		return components
 	}
 
 	var hostname: String {
 		// swiftlint:disable switch_case_alignment
 		switch self {
-			case .productDataCheck, .getSize:
+			case .productDataCheck:
 				return Virtusize.environment.servicesUrl()
+            case  .getSize:
+                return Virtusize.environment.getSizeUrl()
 			case .virtusizeWebView:
 				return Virtusize.environment.virtusizeStaticApiUrl()
 			case .i18n:

--- a/Virtusize/Sources/Internal/API/VirtusizeAPIRequest.swift
+++ b/Virtusize/Sources/Internal/API/VirtusizeAPIRequest.swift
@@ -177,6 +177,25 @@ extension APIRequest {
 		) else {
 			return nil
 		}
+/*
+ Chirag: Belows Logic is for to check request Body
+        // Print JSON from data
+    do {
+     
+            if let json = try JSONSerialization.jsonObject(with: jsonData, options: []) as? [String: Any] {
+                // Convert JSON object back to Data for pretty printing
+                let prettyPrintedData = try JSONSerialization.data(withJSONObject: json, options: .prettyPrinted)
+                
+                // Convert the Data to a string
+                if let prettyPrintedString = String(data: prettyPrintedData, encoding: .utf8) {
+                    print(prettyPrintedString)
+                }
+            }
+        } catch {
+            print("Error converting JSON data to string: \(error.localizedDescription)")
+        }
+   */
+       
 		return apiRequest(components: endpoint.components, withPayload: jsonData)
 	}
 

--- a/Virtusize/Sources/Internal/API/VirtusizeAPIService.swift
+++ b/Virtusize/Sources/Internal/API/VirtusizeAPIService.swift
@@ -184,7 +184,7 @@ class VirtusizeAPIService: APIService {
         else {
 			return .failure(nil)
 		}
-      ///  print ("Request: \(request)")
+      
         
      
         

--- a/Virtusize/Sources/Internal/API/VirtusizeAPIService.swift
+++ b/Virtusize/Sources/Internal/API/VirtusizeAPIService.swift
@@ -176,14 +176,19 @@ class VirtusizeAPIService: APIService {
 		productTypes: [VirtusizeProductType],
 		storeProduct: VirtusizeServerProduct,
 		userBodyProfile: VirtusizeUserBodyProfile
-	) -> APIResult<BodyProfileRecommendedSize> {
+	) -> APIResult<BodyProfileRecommendedSizeArray> {
 		guard let request = APIRequest.getBodyProfileRecommendedSize(
 				productTypes: productTypes,
 				storeProduct: storeProduct,
-				userBodyProfile: userBodyProfile) else {
+				userBodyProfile: userBodyProfile)
+        else {
 			return .failure(nil)
 		}
-		return getAPIResultAsync(request: request, type: BodyProfileRecommendedSize.self)
+      ///  print ("Request: \(request)")
+        
+     
+        
+		return getAPIResultAsync(request: request, type: BodyProfileRecommendedSizeArray.self)
 	}
 
 	/// The API request for getting i18 localization texts

--- a/Virtusize/Sources/Internal/Models/VirtusizeAnyCodable.swift
+++ b/Virtusize/Sources/Internal/Models/VirtusizeAnyCodable.swift
@@ -45,7 +45,11 @@ extension VirtusizeAnyCodable: Codable {
 			self.init(array.map { $0.value })
 		} else if let dictionary = try? container.decode([String: VirtusizeAnyCodable].self) {
 			self.init(dictionary.mapValues { $0.value })
-		} else {
+		} else if let dictionary = try? container.decode( [String : [String : Int?]].self) {
+            self.init(dictionary.mapValues { $0.values })
+        }
+       
+            else {
 			throw DecodingError.dataCorruptedError(
 				in: container,
 				debugDescription: "VirtusizeAnyCodable value cannot be decoded"

--- a/Virtusize/Sources/Internal/Models/VirtusizeGetSizeItemsParam.swift
+++ b/Virtusize/Sources/Internal/Models/VirtusizeGetSizeItemsParam.swift
@@ -1,0 +1,27 @@
+//
+//  VirtusizeGetSizeItemsParama.swift
+//  Virtusize
+//
+//  Created by admin on 13/12/23.
+//  Copyright © 2023 Virtusize AB. All rights reserved.
+//
+
+import Foundation
+struct VirtusizeGetSizeItemsParam: Codable {
+    internal init(additionalInfo: [String : VirtusizeAnyCodable] = [:], itemSizesOrig: [String : [String : Int?]] = [:],productType:  String, extProductId: String) {
+        self.additionalInfo = additionalInfo
+        self.itemSizesOrig = itemSizesOrig
+        self.productType = productType
+        self.extProductId = extProductId
+        
+    }
+    
+   
+    var additionalInfo: [String: VirtusizeAnyCodable] = [:]
+    var itemSizesOrig: [String: [String: Int?]] = [:]
+    var productType: String
+    var extProductId: String
+    
+   
+  
+}

--- a/Virtusize/Sources/Internal/Models/VirtusizeGetSizeParams.swift
+++ b/Virtusize/Sources/Internal/Models/VirtusizeGetSizeParams.swift
@@ -91,7 +91,7 @@ internal struct VirtusizeGetSizeParams: Codable {
         if let weight = userBodyProfile?.weight {
             userWeight = Float(weight)
         }
-       let extProductId = storeProduct.externalId
+       //let extProductId = storeProduct.externalId
         
         items = [VirtusizeGetSizeItemsParam(additionalInfo: additionalInfo,itemSizesOrig: itemSizesOrig,productType: productType, extProductId: storeProduct.externalId)]
         

--- a/Virtusize/Sources/Internal/Models/VirtusizeGetSizeParams.swift
+++ b/Virtusize/Sources/Internal/Models/VirtusizeGetSizeParams.swift
@@ -69,13 +69,7 @@ internal struct VirtusizeGetSizeParams: Codable {
             "sizes": VirtusizeAnyCodable(
                 storeProduct.storeProductMeta?.additionalInfo?.sizes ?? [:]
             ),
-//            "modelInfo": VirtusizeAnyCodable(
-//                getModelInfoDict(storeProduct: storeProduct)
-//            ),
-//            "gender": VirtusizeAnyCodable(
-//                storeProduct.storeProductMeta?.additionalInfo?.gender ?? storeProduct.storeProductMeta?.gender ?? nil
-//            )
-            
+
             "gender": VirtusizeAnyCodable(
                 userBodyProfile?.gender ?? nil
             )

--- a/Virtusize/Sources/Internal/Models/VirtusizeGetSizeParams.swift
+++ b/Virtusize/Sources/Internal/Models/VirtusizeGetSizeParams.swift
@@ -51,8 +51,8 @@ internal struct VirtusizeGetSizeParams: Codable {
         
     ) {
         
-   ///Chirag : Commented modelInfo not getting proper value  but its optional
-   ///Chirag: Gender value geting from userBodyProfile, not getting from storeProduct.storeProductMeta?.additionalInfo
+   ///Chirag : Commented modelInfo not geting proper value  but its optional
+   ///Chirag: Gender value geting from userBodyProfile, not geting from storeProduct.storeProductMeta?.additionalInfo
        let additionalInfo = [
             "brand": VirtusizeAnyCodable(
                 storeProduct.storeProductMeta?.additionalInfo?.brand ?? storeProduct.storeProductMeta?.brand ?? ""

--- a/Virtusize/Sources/Internal/Models/VirtusizeGetSizeParams.swift
+++ b/Virtusize/Sources/Internal/Models/VirtusizeGetSizeParams.swift
@@ -51,8 +51,8 @@ internal struct VirtusizeGetSizeParams: Codable {
         
     ) {
         
-   ///Chirag : Commented modelInfo not geting proper value  but its optional
-   ///Chirag: Gender value geting from userBodyProfile, not geting from storeProduct.storeProductMeta?.additionalInfo
+   ///Chirag : Commented modelInfo not getting proper value  but its optional
+   ///Chirag: Gender value getting from userBodyProfile, not getting from storeProduct.storeProductMeta?.additionalInfo
        let additionalInfo = [
             "brand": VirtusizeAnyCodable(
                 storeProduct.storeProductMeta?.additionalInfo?.brand ?? storeProduct.storeProductMeta?.brand ?? ""

--- a/Virtusize/Sources/Internal/Models/VirtusizeGetSizeParams.swift
+++ b/Virtusize/Sources/Internal/Models/VirtusizeGetSizeParams.swift
@@ -25,22 +25,16 @@
 // swiftlint:disable line_length
 /// The structure that wraps the parameters for the API request to get the recommended size based on a user's body profile
 internal struct VirtusizeGetSizeParams: Codable {
-    /// The store product additional info
-   // var additionalInfo: [String: VirtusizeAnyCodable] = [:]
+   
     /// The user body data
     var bodyData: [String: [String: VirtusizeAnyCodable]] = [:]
-    /// The store product size info
-  //  var itemSizesOrig: [String: [String: Int?]] = [:]
-    /// The store product type
-  //  var productType: String = ""
     /// The user's gender
     var userGender: String = ""
     /// The user's height
     var userHeight: Int?
     /// The user's weight
     var userWeight: Float?
-    /// The external product ID provided by the client
-   // var extProductId: String = ""
+
     
     var items : [VirtusizeGetSizeItemsParam]
     

--- a/Virtusize/Sources/Internal/Models/VirtusizeGetSizeParams.swift
+++ b/Virtusize/Sources/Internal/Models/VirtusizeGetSizeParams.swift
@@ -52,7 +52,7 @@ internal struct VirtusizeGetSizeParams: Codable {
     ) {
         
    ///Chirag : Commented modelInfo not getting proper value  but its optional
-   ///Chirag: Gender value geting from userBodyProfile, not geting from storeProduct.storeProductMeta?.additionalInfo
+   ///Chirag: Gender value geting from userBodyProfile, not getting from storeProduct.storeProductMeta?.additionalInfo
        let additionalInfo = [
             "brand": VirtusizeAnyCodable(
                 storeProduct.storeProductMeta?.additionalInfo?.brand ?? storeProduct.storeProductMeta?.brand ?? ""

--- a/Virtusize/Sources/Internal/Models/VirtusizeGetSizeParams.swift
+++ b/Virtusize/Sources/Internal/Models/VirtusizeGetSizeParams.swift
@@ -79,7 +79,7 @@ internal struct VirtusizeGetSizeParams: Codable {
         if let weight = userBodyProfile?.weight {
             userWeight = Float(weight)
         }
-       //let extProductId = storeProduct.externalId
+      
         
         items = [VirtusizeGetSizeItemsParam(additionalInfo: additionalInfo,itemSizesOrig: itemSizesOrig,productType: productType, extProductId: storeProduct.externalId)]
         

--- a/Virtusize/Sources/Internal/Models/VirtusizeGetSizeParams.swift
+++ b/Virtusize/Sources/Internal/Models/VirtusizeGetSizeParams.swift
@@ -52,7 +52,7 @@ internal struct VirtusizeGetSizeParams: Codable {
     ) {
         
    ///Chirag : Commented modelInfo not getting proper value  but its optional
-   ///Chirag: Gender value geting from userBodyProfile, not geeting from storeProduct.storeProductMeta?.additionalInfo
+   ///Chirag: Gender value geting from userBodyProfile, not geting from storeProduct.storeProductMeta?.additionalInfo
        let additionalInfo = [
             "brand": VirtusizeAnyCodable(
                 storeProduct.storeProductMeta?.additionalInfo?.brand ?? storeProduct.storeProductMeta?.brand ?? ""

--- a/Virtusize/Sources/Internal/Models/VirtusizeGetSizeParams.swift
+++ b/Virtusize/Sources/Internal/Models/VirtusizeGetSizeParams.swift
@@ -25,63 +25,79 @@
 // swiftlint:disable line_length
 /// The structure that wraps the parameters for the API request to get the recommended size based on a user's body profile
 internal struct VirtusizeGetSizeParams: Codable {
-	/// The store product additional info
-	var additionalInfo: [String: VirtusizeAnyCodable] = [:]
-	/// The user body data
-	var bodyData: [String: [String: VirtusizeAnyCodable]] = [:]
-	/// The store product size info
-	var itemSizesOrig: [String: [String: Int?]] = [:]
-	/// The store product type
-	var productType: String = ""
-	/// The user's gender
-	var userGender: String = ""
-	/// The user's height
-	var userHeight: Int?
-	/// The user's weight
-	var userWeight: Float?
-	/// The external product ID provided by the client
-	var extProductId: String = ""
-
-	/// Initializes the VirtusizeGetSizeParams structure
-	///
-	/// - Parameters:
-	///   - productTypes: The list of available `VirtusizeProductType`
-	///   - storeProduct: The store product info in the type of `VirtusizeInternalProduct`
-	///   - userBodyProfile: The user body profile
-	init(
-		productTypes: [VirtusizeProductType],
-		storeProduct: VirtusizeServerProduct,
-		userBodyProfile: VirtusizeUserBodyProfile?
-	) {
-		additionalInfo = [
-			"brand": VirtusizeAnyCodable(
-				storeProduct.storeProductMeta?.additionalInfo?.brand ?? storeProduct.storeProductMeta?.brand ?? ""
-			),
-			"fit": VirtusizeAnyCodable(
-				storeProduct.storeProductMeta?.additionalInfo?.fit ?? "regular"
-			),
-			"sizes": VirtusizeAnyCodable(
-				storeProduct.storeProductMeta?.additionalInfo?.sizes ?? [:]
-			),
-			"modelInfo": VirtusizeAnyCodable(
-				getModelInfoDict(storeProduct: storeProduct)
-			),
-			"gender": VirtusizeAnyCodable(
-				storeProduct.storeProductMeta?.additionalInfo?.gender ?? storeProduct.storeProductMeta?.gender ?? nil
-			)
-		]
-		bodyData = getBodyDataDict(userBodyProfile: userBodyProfile)
-		itemSizesOrig = getItemSizesDict(storeProduct: storeProduct)
-		if let index = productTypes.firstIndex(where: { $0.id == storeProduct.productType }) {
-			productType = productTypes[index].name
-		}
-		userGender = userBodyProfile?.gender ?? ""
-		userHeight = userBodyProfile?.height
-		if let weight = userBodyProfile?.weight {
-			userWeight = Float(weight)
-		}
-		extProductId = storeProduct.externalId
-	}
+    /// The store product additional info
+   // var additionalInfo: [String: VirtusizeAnyCodable] = [:]
+    /// The user body data
+    var bodyData: [String: [String: VirtusizeAnyCodable]] = [:]
+    /// The store product size info
+  //  var itemSizesOrig: [String: [String: Int?]] = [:]
+    /// The store product type
+  //  var productType: String = ""
+    /// The user's gender
+    var userGender: String = ""
+    /// The user's height
+    var userHeight: Int?
+    /// The user's weight
+    var userWeight: Float?
+    /// The external product ID provided by the client
+   // var extProductId: String = ""
+    
+    var items : [VirtusizeGetSizeItemsParam]
+    
+    /// Initializes the VirtusizeGetSizeParams structure
+    ///
+    /// - Parameters:
+    ///   - productTypes: The list of available `VirtusizeProductType`
+    ///   - storeProduct: The store product info in the type of `VirtusizeInternalProduct`
+    ///   - userBodyProfile: The user body profile
+    init(
+        productTypes: [VirtusizeProductType],
+        storeProduct: VirtusizeServerProduct,
+        userBodyProfile: VirtusizeUserBodyProfile?
+        
+    ) {
+        
+   ///Chirag : Commented modelInfo not getting proper value  but its optional
+   ///Chirag: Gender value geting from userBodyProfile, not geeting from storeProduct.storeProductMeta?.additionalInfo
+       let additionalInfo = [
+            "brand": VirtusizeAnyCodable(
+                storeProduct.storeProductMeta?.additionalInfo?.brand ?? storeProduct.storeProductMeta?.brand ?? ""
+            ),
+            "fit": VirtusizeAnyCodable(
+                storeProduct.storeProductMeta?.additionalInfo?.fit ?? "regular"
+            ),
+            "sizes": VirtusizeAnyCodable(
+                storeProduct.storeProductMeta?.additionalInfo?.sizes ?? [:]
+            ),
+//            "modelInfo": VirtusizeAnyCodable(
+//                getModelInfoDict(storeProduct: storeProduct)
+//            ),
+//            "gender": VirtusizeAnyCodable(
+//                storeProduct.storeProductMeta?.additionalInfo?.gender ?? storeProduct.storeProductMeta?.gender ?? nil
+//            )
+            
+            "gender": VirtusizeAnyCodable(
+                userBodyProfile?.gender ?? nil
+            )
+        ]
+        bodyData = getBodyDataDict(userBodyProfile: userBodyProfile)
+        let itemSizesOrig = getItemSizesDict(storeProduct: storeProduct)
+        var productType = ""
+        if let index = productTypes.firstIndex(where: { $0.id == storeProduct.productType }) {
+            productType = productTypes[index].name
+        }
+        userGender = userBodyProfile?.gender ?? ""
+        userHeight = userBodyProfile?.height
+        if let weight = userBodyProfile?.weight {
+            userWeight = Float(weight)
+        }
+       let extProductId = storeProduct.externalId
+        
+        items = [VirtusizeGetSizeItemsParam(additionalInfo: additionalInfo,itemSizesOrig: itemSizesOrig,productType: productType, extProductId: storeProduct.externalId)]
+        
+        
+    }
+}
 
 	/// Gets the dictionary of the model info
 	private func getModelInfoDict(storeProduct: VirtusizeServerProduct) -> [String: Any] {
@@ -130,4 +146,5 @@ internal struct VirtusizeGetSizeParams: Codable {
 		}
 		return itemSizesDict
 	}
-}
+    
+

--- a/Virtusize/Sources/Models/BodyProfileRecommendedSize.swift
+++ b/Virtusize/Sources/Models/BodyProfileRecommendedSize.swift
@@ -23,15 +23,100 @@
 //
 
 /// This structure represents the response for the recommendation API based on the user body profile
+//public struct BodyProfileRecommendedSize: Codable {
+//	/// The recommended size name
+//	let sizeName: String
+//
+//	/// The store product that is associated with this recommendation
+//	public var product: VirtusizeServerProduct?
+//
+//	public init(sizeName: String, product: VirtusizeServerProduct? = nil) {
+//		self.sizeName = sizeName
+//		self.product = product
+//	}
+//}
+//public struct BodyProfileRecommendedSize: Codable {
+//    let extProductId: String?
+//    let sizeName: String?
+//    let secondSize: String?
+//    let fitScore : Int?
+//    let secondFitScore: Int?
+//    let fitScoreDifference: Int?
+//    let virtualItem: VirtualItem?
+//    let willFit: Bool?
+//    let thresholdFitScore: Int?
+//    let scenario: String?
+//    let willFitForSizes: WillFitForSizes?
+//    
+//    init(extProductId: String? = nil, sizeName: String, secondSize: String? = nil, fitScore: Int? = nil, secondFitScore: Int? = nil, fitScoreDifference: Int? = nil, virtualItem: VirtualItem? = nil, willFit : Bool? = nil, thresholdFitScore: Int? = nil, scenario : String? = nil, willFitForSizes: WillFitForSizes? = nil ) {
+//        self.extProductId = extProductId
+//        self.sizeName = sizeName
+//        self.secondSize = secondSize
+//        self.fitScore = fitScore
+//        self.secondFitScore = secondFitScore
+//        self.fitScoreDifference = fitScoreDifference
+//        self.virtualItem = virtualItem
+//        self.willFit = willFit
+//        self.thresholdFitScore = thresholdFitScore
+//        self.scenario = scenario
+//        self.willFitForSizes = willFitForSizes
+//    }
+//}
 public struct BodyProfileRecommendedSize: Codable {
-	/// The recommended size name
-	let sizeName: String
-
-	/// The store product that is associated with this recommendation
-	public var product: VirtusizeServerProduct?
-
-	public init(sizeName: String, product: VirtusizeServerProduct? = nil) {
-		self.sizeName = sizeName
-		self.product = product
-	}
+    let extProductId : String?
+    let sizeName : String?
+    let secondSize : String?
+    let fitScore : Double?
+    let secondFitScore : Double?
+    let fitScoreDifference : Double?
+    let virtualItem : VirtualItem?
+    let willFit : Bool?
+    let thresholdFitScore : Double?
+    let scenario : String?
+    let willFitForSizes : WillFitForSizes?
+    
+    init(extProductId: String? = nil, sizeName: String, secondSize: String? = nil, fitScore: Double? = nil, secondFitScore: Double? = nil, fitScoreDifference: Double? = nil, virtualItem: VirtualItem? = nil, willFit : Bool? = nil, thresholdFitScore: Double? = nil, scenario : String? = nil, willFitForSizes: WillFitForSizes? = nil ) {
+        self.extProductId = extProductId
+        self.sizeName = sizeName
+        self.secondSize = secondSize
+        self.fitScore = fitScore
+        self.secondFitScore = secondFitScore
+        self.fitScoreDifference = fitScoreDifference
+        self.virtualItem = virtualItem
+        self.willFit = willFit
+        self.thresholdFitScore = thresholdFitScore
+        self.scenario = scenario
+        self.willFitForSizes = willFitForSizes
+    }
 }
+public typealias BodyProfileRecommendedSizeArray = [BodyProfileRecommendedSize]
+// MARK: - VirtualItem
+struct VirtualItem: Codable {
+    let bust : Double?
+    let waist : Double?
+    let hip : Double?
+    let inseam: String?
+    let sleeve: String?
+}
+
+// MARK: - WillFitForSizes
+struct WillFitForSizes: Codable {
+    let large : Bool?
+    let  medium  : Bool?
+    let extra_small: Bool?
+    let extra_large: Bool?
+    let small: Bool?
+    
+    
+    enum CodingKeys: String, CodingKey {
+
+        case large = "large"
+        case medium = "medium"
+        case extra_small = "extra small"
+        case extra_large = "extra large"
+        case small = "small"
+        
+    }
+}
+
+

--- a/Virtusize/Sources/Models/BodyProfileRecommendedSize.swift
+++ b/Virtusize/Sources/Models/BodyProfileRecommendedSize.swift
@@ -103,8 +103,8 @@ struct VirtualItem: Codable {
 struct WillFitForSizes: Codable {
     let large : Bool?
     let  medium  : Bool?
-    let extra_small: Bool?
-    let extra_large: Bool?
+    let extraSmall: Bool?
+    let extraLarge: Bool?
     let small: Bool?
     
     
@@ -112,8 +112,8 @@ struct WillFitForSizes: Codable {
 
         case large = "large"
         case medium = "medium"
-        case extra_small = "extra small"
-        case extra_large = "extra large"
+        case extraSmall = "extra small"
+        case extraLarge = "extra large"
         case small = "small"
         
     }

--- a/Virtusize/Sources/Models/BodyProfileRecommendedSize.swift
+++ b/Virtusize/Sources/Models/BodyProfileRecommendedSize.swift
@@ -23,45 +23,8 @@
 //
 
 /// This structure represents the response for the recommendation API based on the user body profile
-//public struct BodyProfileRecommendedSize: Codable {
-//	/// The recommended size name
-//	let sizeName: String
-//
-//	/// The store product that is associated with this recommendation
-//	public var product: VirtusizeServerProduct?
-//
-//	public init(sizeName: String, product: VirtusizeServerProduct? = nil) {
-//		self.sizeName = sizeName
-//		self.product = product
-//	}
-//}
-//public struct BodyProfileRecommendedSize: Codable {
-//    let extProductId: String?
-//    let sizeName: String?
-//    let secondSize: String?
-//    let fitScore : Int?
-//    let secondFitScore: Int?
-//    let fitScoreDifference: Int?
-//    let virtualItem: VirtualItem?
-//    let willFit: Bool?
-//    let thresholdFitScore: Int?
-//    let scenario: String?
-//    let willFitForSizes: WillFitForSizes?
-//    
-//    init(extProductId: String? = nil, sizeName: String, secondSize: String? = nil, fitScore: Int? = nil, secondFitScore: Int? = nil, fitScoreDifference: Int? = nil, virtualItem: VirtualItem? = nil, willFit : Bool? = nil, thresholdFitScore: Int? = nil, scenario : String? = nil, willFitForSizes: WillFitForSizes? = nil ) {
-//        self.extProductId = extProductId
-//        self.sizeName = sizeName
-//        self.secondSize = secondSize
-//        self.fitScore = fitScore
-//        self.secondFitScore = secondFitScore
-//        self.fitScoreDifference = fitScoreDifference
-//        self.virtualItem = virtualItem
-//        self.willFit = willFit
-//        self.thresholdFitScore = thresholdFitScore
-//        self.scenario = scenario
-//        self.willFitForSizes = willFitForSizes
-//    }
-//}
+
+
 public struct BodyProfileRecommendedSize: Codable {
     let extProductId : String?
     let sizeName : String?

--- a/Virtusize/Sources/Models/BodyProfileRecommendedSize.swift
+++ b/Virtusize/Sources/Models/BodyProfileRecommendedSize.swift
@@ -37,7 +37,7 @@ public struct BodyProfileRecommendedSize: Codable {
     let thresholdFitScore : Double?
     let scenario : String?
     let willFitForSizes : WillFitForSizes?
-    
+    // swiftlint:disable line_length
     init(extProductId: String? = nil, sizeName: String, secondSize: String? = nil, fitScore: Double? = nil, secondFitScore: Double? = nil, fitScoreDifference: Double? = nil, virtualItem: VirtualItem? = nil, willFit : Bool? = nil, thresholdFitScore: Double? = nil, scenario : String? = nil, willFitForSizes: WillFitForSizes? = nil ) {
         self.extProductId = extProductId
         self.sizeName = sizeName
@@ -51,6 +51,7 @@ public struct BodyProfileRecommendedSize: Codable {
         self.scenario = scenario
         self.willFitForSizes = willFitForSizes
     }
+    // swiftlint:enable line_length
 }
 public typealias BodyProfileRecommendedSizeArray = [BodyProfileRecommendedSize]
 // MARK: - VirtualItem

--- a/Virtusize/Sources/Models/VirtusizeEnvironment.swift
+++ b/Virtusize/Sources/Models/VirtusizeEnvironment.swift
@@ -24,29 +24,29 @@
 
 /// This enum contains all available Virtusize environments
 public enum VirtusizeEnvironment: String, CaseIterable {
-	case testing="testing.virtusize.jp"
-	case staging="staging.virtusize.com"
-	case global="api.virtusize.com"
-	case japan="api.virtusize.jp"
-	case korea="api.virtusize.kr"
+	case TESTING="testing.virtusize.jp"
+	case STAGING="staging.virtusize.com"
+	case GLOBAL="api.virtusize.com"
+	case JAPAN="api.virtusize.jp"
+	case KOREA="api.virtusize.kr"
 
 	var isProdEnv: Bool {
-		return self == .global || self == .japan || self == .korea
+		return self == .GLOBAL || self == .JAPAN || self == .KOREA
 	}
 
 	/// Gets the services URL for the `productDataCheck` and `getSize` requests
 	internal func servicesUrl() -> String {
 		// swiftlint:disable switch_case_alignment
 		switch self {
-			case .testing:
+			case .TESTING:
 				return "services.virtusize.jp"
-			case .staging:
+			case .STAGING:
 				return "services.virtusize.com"
-			case .global:
+			case .GLOBAL:
 				return "services.virtusize.com"
-			case .japan:
+			case .JAPAN:
 				return "services.virtusize.jp"
-			case .korea:
+			case .KOREA:
 				return "services.virtusize.kr"
 		}
 	}
@@ -55,15 +55,15 @@ public enum VirtusizeEnvironment: String, CaseIterable {
     internal func getSizeUrl() -> String {
         // swiftlint:disable switch_case_alignment
         switch self {
-            case .testing:
+            case .TESTING:
                 return "size-recommendation.virtusize.jp"
-            case .staging:
+            case .STAGING:
                 return "size-recommendation.virtusize.com"
-            case .global:
+            case .GLOBAL:
                 return "size-recommendation.virtusize.com"
-            case .japan:
+            case .JAPAN:
                 return "size-recommendation.virtusize.jp"
-            case .korea:
+            case .KOREA:
                 return "size-recommendation.virtusize.kr"
         }
     }
@@ -76,11 +76,11 @@ public enum VirtusizeEnvironment: String, CaseIterable {
 	/// Gets the static API URL for the `VirtusizeWebView` request
 	internal func virtusizeStaticApiUrl() -> String {
 		switch self {
-			case .staging, .global:
+			case .STAGING, .GLOBAL:
 				return "static.api.virtusize.com"
-			case .testing, .japan:
+			case .TESTING, .JAPAN:
 				return "static.api.virtusize.jp"
-			case .korea:
+			case .KOREA:
 				return "static.api.virtusize.kr"
 		}
 	}
@@ -88,15 +88,15 @@ public enum VirtusizeEnvironment: String, CaseIterable {
 	/// Gets the event API URL corresponding to the Virtusize environment
 	internal func eventApiUrl() -> String {
 		switch self {
-			case .testing:
+			case .TESTING:
 				return "events.testing.virtusize.jp"
-			case .staging:
+			case .STAGING:
 				return "events.staging.virtusize.com"
-			case .japan:
+			case .JAPAN:
 				return "events.virtusize.jp"
-			case .global:
+			case .GLOBAL:
 				return "events.virtusize.com"
-			case .korea:
+			case .KOREA:
 				return "events.virtusize.kr"
 		}
 	}
@@ -104,11 +104,11 @@ public enum VirtusizeEnvironment: String, CaseIterable {
 	/// Gets the `VirtusizeRegion` corresponding to the Virtusize environment
 	internal func virtusizeRegion() -> VirtusizeRegion {
 		switch self {
-			case .staging, .global:
+			case .STAGING, .GLOBAL:
 				return VirtusizeRegion.COM
-			case .testing, .japan:
+			case .TESTING, .JAPAN:
 				return VirtusizeRegion.JAPAN
-			case .korea:
+			case .KOREA:
 				return VirtusizeRegion.KOREA
 		}
 	}

--- a/Virtusize/Sources/Models/VirtusizeEnvironment.swift
+++ b/Virtusize/Sources/Models/VirtusizeEnvironment.swift
@@ -50,6 +50,23 @@ public enum VirtusizeEnvironment: String, CaseIterable {
 				return "services.virtusize.kr"
 		}
 	}
+    
+    /// Gets the services URL for the ``getSize` requests
+    internal func getSizeUrl() -> String {
+        // swiftlint:disable switch_case_alignment
+        switch self {
+            case .testing:
+                return "size-recommendation.virtusize.jp"
+            case .staging:
+                return "size-recommendation.virtusize.com"
+            case .global:
+                return "size-recommendation.virtusize.com"
+            case .japan:
+                return "size-recommendation.virtusize.jp"
+            case .korea:
+                return "size-recommendation.virtusize.kr"
+        }
+    }
 
 	/// Gets the URL for the `i18n` request
 	internal func i18nUrl() -> String {

--- a/Virtusize/Sources/Virtusize.swift
+++ b/Virtusize/Sources/Virtusize.swift
@@ -35,8 +35,8 @@ public class Virtusize {
 	/// The user id that is the unique user id from the client system
 	public static var userID: String?
 
-	/// The Virtusize environment that defaults to the `global` domain
-	public static var environment = VirtusizeEnvironment.global
+	/// The Virtusize environment that defaults to the `GLOBAL` domain
+	public static var environment = VirtusizeEnvironment.GLOBAL
 
 	/// The Virtusize parameter object contains the parameters to be passed to the Virtusize web app
 	public static var params: VirtusizeParams? = VirtusizeParamsBuilder().build()

--- a/Virtusize/Sources/VirtusizeConfiguration.swift
+++ b/Virtusize/Sources/VirtusizeConfiguration.swift
@@ -25,5 +25,5 @@
 import Foundation
 
 struct VirtusizeConfiguration {
-	static let SDKVersion = "2.5.4"
+	static let SDKVersion = "2.5.7"
 }

--- a/Virtusize/Sources/VirtusizeRepository.swift
+++ b/Virtusize/Sources/VirtusizeRepository.swift
@@ -45,7 +45,7 @@ internal class VirtusizeRepository: NSObject {
 	private var userProducts: [VirtusizeServerProduct]?
 	private var userBodyProfile: VirtusizeUserBodyProfile?
 	private var sizeComparisonRecommendedSize: SizeComparisonRecommendedSize?
-	private var bodyProfileRecommendedSize: BodyProfileRecommendedSize?
+	private var bodyProfileRecommendedSize: BodyProfileRecommendedSizeArray?
 
 	/// A set to cache the store product information of all the visited products
 	private var serverStoreProductSet: Set<VirtusizeServerProduct> = []
@@ -189,14 +189,18 @@ internal class VirtusizeRepository: NSObject {
 				Virtusize.inPageError = (true, storeProduct!.externalId)
 				return
 			}
-		}
+ 		}
 
 		if let userBodyProfile = userBodyProfile {
+            
 			bodyProfileRecommendedSize = VirtusizeAPIService.getBodyProfileRecommendedSizeAsync(
 				productTypes: productTypes!,
 				storeProduct: storeProduct!,
 				userBodyProfile: userBodyProfile
 			).success
+            
+        
+            
 		}
 
 		var userProducts = self.userProducts ?? []
@@ -268,9 +272,9 @@ internal class VirtusizeRepository: NSObject {
 			case .compareProduct:
 				Virtusize.sizeRecData = (product, sizeComparisonRecommendedSize, nil)
 			case .body:
-				Virtusize.sizeRecData = (product, nil, bodyProfileRecommendedSize)
+            Virtusize.sizeRecData = (product, nil, bodyProfileRecommendedSize?[0])
 			default:
-				Virtusize.sizeRecData = (product, sizeComparisonRecommendedSize, bodyProfileRecommendedSize)
+            Virtusize.sizeRecData = (product, sizeComparisonRecommendedSize, bodyProfileRecommendedSize?[0])
 		}
 	}
 
@@ -281,7 +285,8 @@ internal class VirtusizeRepository: NSObject {
 		guard let recommendedSize = recommendedSize else {
 			return
 		}
-		bodyProfileRecommendedSize = BodyProfileRecommendedSize(sizeName: recommendedSize)
+        bodyProfileRecommendedSize?.append(BodyProfileRecommendedSize(sizeName: recommendedSize))
+		//bodyProfileRecommendedSize = BodyProfileRecommendedSize(sizeName: recommendedSize)
 	}
 
 	/// Removes the deleted user product by the product ID from the user product list

--- a/Virtusize/Sources/VirtusizeRepository.swift
+++ b/Virtusize/Sources/VirtusizeRepository.swift
@@ -286,7 +286,7 @@ internal class VirtusizeRepository: NSObject {
 			return
 		}
         bodyProfileRecommendedSize?.append(BodyProfileRecommendedSize(sizeName: recommendedSize))
-		//bodyProfileRecommendedSize = BodyProfileRecommendedSize(sizeName: recommendedSize)
+		
 	}
 
 	/// Removes the deleted user product by the product ID from the user product list

--- a/Virtusize/Tests/APIEndpointsTests.swift
+++ b/Virtusize/Tests/APIEndpointsTests.swift
@@ -170,12 +170,12 @@ class APIEndpointsTests: XCTestCase {
     func testGetSizeEndpoint_returnExpectedComponents() {
         let endpoint = APIEndpoints.getSize
 
-        XCTAssertEqual(endpoint.components.host, "services.virtusize.com")
-        XCTAssertEqual(endpoint.components.path, "/stg/ds-functions/size-rec/get-size")
+        XCTAssertEqual(endpoint.components.host, "size-recommendation.virtusize.com")
+        XCTAssertEqual(endpoint.components.path, "/item")
 
         XCTAssertNil(endpoint.components.queryItems)
     }
-
+    
     private func getQueryParametersDict(queryItems: [URLQueryItem]?) -> [String: String] {
         guard let items = queryItems else {
             return [:]

--- a/Virtusize/Tests/APIEndpointsTests.swift
+++ b/Virtusize/Tests/APIEndpointsTests.swift
@@ -32,7 +32,7 @@ class APIEndpointsTests: XCTestCase {
     override func setUpWithError() throws {
         Virtusize.APIKey = "test_APIKey"
         Virtusize.userID = "123"
-        Virtusize.environment = .staging
+        Virtusize.environment = .STAGING
     }
 
     override func tearDownWithError() throws {
@@ -55,7 +55,7 @@ class APIEndpointsTests: XCTestCase {
     }
 
     func testProductMetaDataHintsEndpoint_returnExpectedComponents() {
-        Virtusize.environment = .global
+        Virtusize.environment = .GLOBAL
         let endpoint = APIEndpoints.productMetaDataHints
 
         XCTAssertEqual(endpoint.components.host, "api.virtusize.com")
@@ -65,7 +65,7 @@ class APIEndpointsTests: XCTestCase {
     }
 
     func testEventsEndpoint_returnExpectedComponents() {
-        Virtusize.environment = .korea
+        Virtusize.environment = .KOREA
         let endpoint = APIEndpoints.events
         XCTAssertEqual(endpoint.components.host, "events.virtusize.kr")
         XCTAssertEqual(endpoint.components.path, "")
@@ -74,7 +74,7 @@ class APIEndpointsTests: XCTestCase {
     }
 
     func testVirtusizeWebViewEndpoint_japanEnv_returnExpectedComponents() {
-        Virtusize.environment = .japan
+        Virtusize.environment = .JAPAN
 
         let endpoint = APIEndpoints.virtusizeWebView
 
@@ -86,7 +86,7 @@ class APIEndpointsTests: XCTestCase {
     }
 
 	func testVirtusizeWebViewEndpoint_stagingEnv_returnExpectedComponents() {
-		Virtusize.environment = .staging
+		Virtusize.environment = .STAGING
 
 		let endpoint = APIEndpoints.virtusizeWebView
 

--- a/Virtusize/Tests/APIEventTests.swift
+++ b/Virtusize/Tests/APIEventTests.swift
@@ -52,8 +52,8 @@ class APIEventTests: XCTestCase {
                        UIDevice.current.orientation.isLandscape ? "landscape" : "portrait"
         )
         XCTAssertEqual(payloadJson?["browserResolution"], "\(Int(screenSize.height))x\(Int(screenSize.width))")
-        XCTAssertEqual(payloadJson?["integrationVersion"], "2.5.4")
-        XCTAssertEqual(payloadJson?["snippetVersion"], "2.5.4")
+        XCTAssertEqual(payloadJson?["integrationVersion"], "2.5.7")
+        XCTAssertEqual(payloadJson?["snippetVersion"], "2.5.7")
     }
 
     func testAPIEvent_alignProductDataCheckContext_hasExpectedPayload() {

--- a/Virtusize/Tests/APIRequestTests.swift
+++ b/Virtusize/Tests/APIRequestTests.swift
@@ -157,10 +157,11 @@ class APIRequestTests: XCTestCase {
         XCTAssertNotNil(apiRequest?.httpBody)
         let actualParams = try? JSONDecoder().decode(VirtusizeGetSizeParams.self, from: apiRequest!.httpBody!)
         XCTAssertNotNil(actualParams)
-        XCTAssertEqual(actualParams?.additionalInfo.count, 5)
-        XCTAssertEqual(actualParams?.additionalInfo["gender"]?.value as? String, "male")
+        XCTAssertEqual(actualParams?.items.additionalInfo.count, 5)
+       
+        XCTAssertEqual(actualParams?.items.additionalInfo["gender"]?.value as? String, "male")
         XCTAssertEqual(
-            actualParams?.additionalInfo["sizes"]?.value as? [String: [String: Int?]],
+            actualParams?.items.additionalInfo["sizes"]?.value as? [String: [String: Int?]],
             ["37": [
                 "sleeve": 845,
                 "bust": 660,
@@ -179,27 +180,27 @@ class APIRequestTests: XCTestCase {
             ]
         )
         XCTAssertEqual(
-            (actualParams?.additionalInfo["modelInfo"]?.value as? [String: Any])?["size"] as? String,
+            (actualParams?.items.additionalInfo["modelInfo"]?.value as? [String: Any])?["size"] as? String,
             "38"
         )
         XCTAssertEqual(
-            (actualParams?.additionalInfo["modelInfo"]?.value as? [String: Any])?["hip"] as? Int,
+            (actualParams?.items.additionalInfo["modelInfo"]?.value as? [String: Any])?["hip"] as? Int,
             85
         )
-        XCTAssertEqual(actualParams?.additionalInfo["brand"]?.value as? String, "Virtusize")
-        XCTAssertEqual(actualParams?.additionalInfo["fit"]?.value as? String, "regular")
+        XCTAssertEqual(actualParams?.items.additionalInfo["brand"]?.value as? String, "Virtusize")
+        XCTAssertEqual(actualParams?.items.additionalInfo["fit"]?.value as? String, "regular")
         XCTAssertEqual(actualParams?.bodyData.count, 22)
         XCTAssertEqual((actualParams?.bodyData["chest"])?["value"]?.value as? Int, 755)
-        XCTAssertEqual(actualParams?.itemSizesOrig.count, 3)
-        XCTAssertEqual(actualParams?.itemSizesOrig["36"]?["bust"], 645)
+        XCTAssertEqual(actualParams?.items.itemSizesOrig.count, 3)
+        XCTAssertEqual(actualParams?.items.itemSizesOrig["36"]?["bust"], 645)
 		XCTAssertEqual(actualParams?.userGender, "female")
 		XCTAssertEqual(actualParams?.userHeight, 1630)
 		XCTAssertEqual(actualParams?.userWeight, 50.00)
-		XCTAssertEqual(actualParams?.extProductId, TestFixtures.externalProductId)
-        XCTAssertEqual(actualParams?.productType, "jacket")
+		XCTAssertEqual(actualParams?.items.extProductId, TestFixtures.externalProductId)
+        XCTAssertEqual(actualParams?.items.productType, "jacket")
 		XCTAssertEqual(
 			apiRequest?.url?.absoluteString,
-			"https://services.virtusize.com/stg/ds-functions/size-rec/get-size"
+			"https://size-recommendation.virtusize.com/item"
 		)
     }
 

--- a/Virtusize/Tests/APIRequestTests.swift
+++ b/Virtusize/Tests/APIRequestTests.swift
@@ -157,11 +157,11 @@ class APIRequestTests: XCTestCase {
         XCTAssertNotNil(apiRequest?.httpBody)
         let actualParams = try? JSONDecoder().decode(VirtusizeGetSizeParams.self, from: apiRequest!.httpBody!)
         XCTAssertNotNil(actualParams)
-        XCTAssertEqual(actualParams?.items.additionalInfo.count, 5)
+        XCTAssertEqual(actualParams?.items.first?.additionalInfo.count, 5)
        
-        XCTAssertEqual(actualParams?.items.additionalInfo["gender"]?.value as? String, "male")
+        XCTAssertEqual(actualParams?.items.first?.additionalInfo["gender"]?.value as? String, "male")
         XCTAssertEqual(
-            actualParams?.items.additionalInfo["sizes"]?.value as? [String: [String: Int?]],
+            actualParams?.items.first?.additionalInfo["sizes"]?.value as? [String: [String: Int?]],
             ["37": [
                 "sleeve": 845,
                 "bust": 660,
@@ -180,24 +180,24 @@ class APIRequestTests: XCTestCase {
             ]
         )
         XCTAssertEqual(
-            (actualParams?.items.additionalInfo["modelInfo"]?.value as? [String: Any])?["size"] as? String,
+            (actualParams?.items.first?.additionalInfo["modelInfo"]?.value as? [String: Any])?["size"] as? String,
             "38"
         )
         XCTAssertEqual(
-            (actualParams?.items.additionalInfo["modelInfo"]?.value as? [String: Any])?["hip"] as? Int,
+            (actualParams?.items.first?.additionalInfo["modelInfo"]?.value as? [String: Any])?["hip"] as? Int,
             85
         )
-        XCTAssertEqual(actualParams?.items.additionalInfo["brand"]?.value as? String, "Virtusize")
-        XCTAssertEqual(actualParams?.items.additionalInfo["fit"]?.value as? String, "regular")
+        XCTAssertEqual(actualParams?.items.first?.additionalInfo["brand"]?.value as? String, "Virtusize")
+        XCTAssertEqual(actualParams?.items.first?.additionalInfo["fit"]?.value as? String, "regular")
         XCTAssertEqual(actualParams?.bodyData.count, 22)
         XCTAssertEqual((actualParams?.bodyData["chest"])?["value"]?.value as? Int, 755)
-        XCTAssertEqual(actualParams?.items.itemSizesOrig.count, 3)
-        XCTAssertEqual(actualParams?.items.itemSizesOrig["36"]?["bust"], 645)
+        XCTAssertEqual(actualParams?.items.first?.itemSizesOrig.count, 3)
+        XCTAssertEqual(actualParams?.items.first?.itemSizesOrig["36"]?["bust"], 645)
 		XCTAssertEqual(actualParams?.userGender, "female")
 		XCTAssertEqual(actualParams?.userHeight, 1630)
 		XCTAssertEqual(actualParams?.userWeight, 50.00)
-		XCTAssertEqual(actualParams?.items.extProductId, TestFixtures.externalProductId)
-        XCTAssertEqual(actualParams?.items.productType, "jacket")
+		XCTAssertEqual(actualParams?.items.first?.extProductId, TestFixtures.externalProductId)
+        XCTAssertEqual(actualParams?.items.first?.productType, "jacket")
 		XCTAssertEqual(
 			apiRequest?.url?.absoluteString,
 			"https://size-recommendation.virtusize.com/item"

--- a/Virtusize/Tests/APIRequestTests.swift
+++ b/Virtusize/Tests/APIRequestTests.swift
@@ -157,9 +157,9 @@ class APIRequestTests: XCTestCase {
         XCTAssertNotNil(apiRequest?.httpBody)
         let actualParams = try? JSONDecoder().decode(VirtusizeGetSizeParams.self, from: apiRequest!.httpBody!)
         XCTAssertNotNil(actualParams)
-        XCTAssertEqual(actualParams?.items.first?.additionalInfo.count, 5)
+        XCTAssertEqual(actualParams?.items.first?.additionalInfo.count, 4)
        
-        XCTAssertEqual(actualParams?.items.first?.additionalInfo["gender"]?.value as? String, "male")
+        XCTAssertEqual(actualParams?.items.first?.additionalInfo["gender"]?.value as? String, "female")
         XCTAssertEqual(
             actualParams?.items.first?.additionalInfo["sizes"]?.value as? [String: [String: Int?]],
             ["37": [
@@ -179,14 +179,8 @@ class APIRequestTests: XCTestCase {
             ]
             ]
         )
-        XCTAssertEqual(
-            (actualParams?.items.first?.additionalInfo["modelInfo"]?.value as? [String: Any])?["size"] as? String,
-            "38"
-        )
-        XCTAssertEqual(
-            (actualParams?.items.first?.additionalInfo["modelInfo"]?.value as? [String: Any])?["hip"] as? Int,
-            85
-        )
+        
+       
         XCTAssertEqual(actualParams?.items.first?.additionalInfo["brand"]?.value as? String, "Virtusize")
         XCTAssertEqual(actualParams?.items.first?.additionalInfo["fit"]?.value as? String, "regular")
         XCTAssertEqual(actualParams?.bodyData.count, 22)

--- a/Virtusize/Tests/APIRequestTests.swift
+++ b/Virtusize/Tests/APIRequestTests.swift
@@ -30,7 +30,7 @@ class APIRequestTests: XCTestCase {
     override func setUpWithError() throws {
         Virtusize.APIKey = "test_APIKey"
         Virtusize.userID = "123"
-        Virtusize.environment = .staging
+        Virtusize.environment = .STAGING
 		UserDefaultsHelper.current.accessToken = "access_token"
     }
 

--- a/Virtusize/Tests/VirtusizeGetSizeParamsTests.swift
+++ b/Virtusize/Tests/VirtusizeGetSizeParamsTests.swift
@@ -35,59 +35,68 @@ class VirtusizeGetSizeParamsTests: XCTestCase {
             userBodyProfile: TestFixtures.getUserBodyProfile()
         )
 
+        
+//        "extProductId": "694",
+//        "brand": "Virtusize",
+//        "modelInfo": {
+//                "hip": 85,
+//                "size": "38",
+//                "bust": 78,
+//                "waist": 56,
+//                "height": 165
+//            },
+//            "fit": "regular"
+//        },
         let expectedGetSizeParamsData = Data(
             """
             {
                 "userGender": "female",
                 "userHeight": 1630,
-                "userWeight": 50.00,
-                "extProductId": "694",
-                "itemSizesOrig": {
-                    "37": {
-                        "sleeve": 845,
-                        "bust": 660,
-                        "height": 760
-                    },
-                    "36": {
-                        "sleeve": 825,
-                        "bust": 645,
-                        "height": 750
-                    },
-                    "35": {
-                        "sleeve": 805,
-                        "bust": 630,
-                        "height": 740
+                "userWeight": 50,
+                "items": [
+                    {
+                        "additionalInfo": {
+                            "brand": "Virtusize",
+                            "fit": "regular",
+                            "sizes": {
+                            "35": {
+                                "sleeve": 805,
+                                "bust": 630,
+                                "height": 740
+                            },
+                            "36": {
+                                "sleeve": 825,
+                                "bust": 645,
+                                "height": 750
+                            },
+                            "37": {
+                                "sleeve": 845,
+                                "bust": 660,
+                                "height": 760
+                            }},
+                            "gender": "female"
+                        },
+                        "itemSizesOrig": {
+                            "35": {
+                                "sleeve": 805,
+                                "bust": 630,
+                                "height": 740
+                            },
+                            "36": {
+                                "sleeve": 825,
+                                "bust": 645,
+                                "height": 750
+                            },
+                            "37": {
+                                "sleeve": 845,
+                                "bust": 660,
+                                "height": 760
+                            }
+                        },
+                        "productType": "jacket",
+                        "extProductId": "694"
                     }
-                },
-                "additionalInfo": {
-                    "sizes": {
-                        "37": {
-                            "sleeve": 845,
-                            "bust": 660,
-                            "height": 760
-                        },
-                        "36": {
-                            "sleeve": 825,
-                            "bust": 645,
-                            "height": 750
-                        },
-                        "35": {
-                            "sleeve": 805,
-                            "bust": 630,
-                            "height": 740
-                        }
-                    },
-                    "gender": "female",
-                    "brand": "Virtusize",
-                    "modelInfo": {
-                        "hip": 85,
-                        "size": "38",
-                        "bust": 78,
-                        "waist": 56,
-                        "height": 165
-                    },
-                    "fit": "regular"
-                },
+                ],
                 "bodyData": {
                     "neck": {
                         "value": 300,
@@ -177,8 +186,7 @@ class VirtusizeGetSizeParamsTests: XCTestCase {
                         "value": 830,
                         "predicted": true
                     }
-                },
-                "productType": "jacket"
+                }
             }
             """.utf8)
 

--- a/Virtusize/Tests/VirtusizeGetSizeParamsTests.swift
+++ b/Virtusize/Tests/VirtusizeGetSizeParamsTests.swift
@@ -35,18 +35,7 @@ class VirtusizeGetSizeParamsTests: XCTestCase {
             userBodyProfile: TestFixtures.getUserBodyProfile()
         )
 
-        
-//        "extProductId": "694",
-//        "brand": "Virtusize",
-//        "modelInfo": {
-//                "hip": 85,
-//                "size": "38",
-//                "bust": 78,
-//                "waist": 56,
-//                "height": 165
-//            },
-//            "fit": "regular"
-//        },
+
         let expectedGetSizeParamsData = Data(
             """
             {
@@ -227,26 +216,7 @@ class VirtusizeGetSizeParamsTests: XCTestCase {
             )!,
             userBodyProfile: nil
         )
-//        {
-//            bodyData =     {
-//            };
-//            items =     (
-//                        {
-//                    additionalInfo =             {
-//                        brand = "";
-//                        fit = regular;
-//                        gender = "<null>";
-//                        sizes =                 {
-//                        };
-//                    };
-//                    extProductId = 694;
-//                    itemSizesOrig =             {
-//                    };
-//                    productType = "";
-//                }
-//            );
-//            userGender = "";
-//        }
+
         
         let expectedGetSizeParamsData = Data(
         """
@@ -268,29 +238,6 @@ class VirtusizeGetSizeParamsTests: XCTestCase {
             "userGender": ""
         }
 """.utf8)
-
-//        let expectedGetSizeParamsData = Data(
-//            """
-//            {
-//                "userGender": "",
-//                "extProductId": "694",
-//                "itemSizesOrig": {},
-//                "additionalInfo": {
-//                    "sizes": {},
-//                    "gender": "<null>",
-//                    "modelInfo": {},
-//                    "brand": "",
-//                    "fit": "regular"
-//                },
-//                "bodyData": {},
-//                "productType": ""
-//            }
-//            """.utf8)
-        
- 
-
-
-
 
 
         

--- a/Virtusize/Tests/VirtusizeGetSizeParamsTests.swift
+++ b/Virtusize/Tests/VirtusizeGetSizeParamsTests.swift
@@ -219,24 +219,73 @@ class VirtusizeGetSizeParamsTests: XCTestCase {
             )!,
             userBodyProfile: nil
         )
-
+//        {
+//            bodyData =     {
+//            };
+//            items =     (
+//                        {
+//                    additionalInfo =             {
+//                        brand = "";
+//                        fit = regular;
+//                        gender = "<null>";
+//                        sizes =                 {
+//                        };
+//                    };
+//                    extProductId = 694;
+//                    itemSizesOrig =             {
+//                    };
+//                    productType = "";
+//                }
+//            );
+//            userGender = "";
+//        }
+        
         let expectedGetSizeParamsData = Data(
-            """
-            {
-                "userGender": "",
-                "extProductId": "694",
-                "itemSizesOrig": {},
-                "additionalInfo": {
-                    "sizes": {},
-                    "gender": "null",
-                    "modelInfo": {},
-                    "brand": "",
-                    "fit": "regular"
-                },
-                "bodyData": {},
-                "productType": ""
-            }
-            """.utf8)
+        """
+        {
+            "bodyData": {},
+            "items": [
+                {
+                    "additionalInfo": {
+                        "brand": "",
+                        "fit": "regular",
+                        "sizes": {},
+                        "gender": null
+                    },
+                    "itemSizesOrig": {},
+                    "productType": "",
+                    "extProductId": "694"
+                }
+            ],
+            "userGender": ""
+        }
+""".utf8)
+
+//        let expectedGetSizeParamsData = Data(
+//            """
+//            {
+//                "userGender": "",
+//                "extProductId": "694",
+//                "itemSizesOrig": {},
+//                "additionalInfo": {
+//                    "sizes": {},
+//                    "gender": "<null>",
+//                    "modelInfo": {},
+//                    "brand": "",
+//                    "fit": "regular"
+//                },
+//                "bodyData": {},
+//                "productType": ""
+//            }
+//            """.utf8)
+        
+ 
+
+
+
+
+
+        
 
         guard let expectedJsonObject = try? JSONSerialization.jsonObject(
                 with: expectedGetSizeParamsData, options: []

--- a/VirtusizeCore/Sources/API/APIService.swift
+++ b/VirtusizeCore/Sources/API/APIService.swift
@@ -60,8 +60,7 @@ open class APIService {
         
 		task = APIService.session.dataTask(with: request) { (data, response, error) in
             
-            print("request :\(request.url?.absoluteString ?? "")")
-            print("error \(error.debugDescription)")
+          
 			guard error == nil else {
 				DispatchQueue.main.async {
 					errorHandler?(VirtusizeError.apiRequestError(request.url, error!.localizedDescription))
@@ -176,7 +175,7 @@ open class APIService {
 		do {
 			let result = try JSONDecoder().decode(type!, from: data)
 			let jsonString = String(data: data, encoding: String.Encoding.utf8)
-           // print("Json String  \(jsonString)" )
+          
 			return .success(result, jsonString)
             
 		} catch {

--- a/VirtusizeCore/Sources/API/APIService.swift
+++ b/VirtusizeCore/Sources/API/APIService.swift
@@ -57,7 +57,11 @@ open class APIService {
 		error errorHandler: ErrorHandler? = nil
 	) {
 		let task: URLSessionDataTask
+        
 		task = APIService.session.dataTask(with: request) { (data, response, error) in
+            
+            print("request :\(request.url?.absoluteString ?? "")")
+            print("error \(error.debugDescription)")
 			guard error == nil else {
 				DispatchQueue.main.async {
 					errorHandler?(VirtusizeError.apiRequestError(request.url, error!.localizedDescription))
@@ -172,7 +176,9 @@ open class APIService {
 		do {
 			let result = try JSONDecoder().decode(type!, from: data)
 			let jsonString = String(data: data, encoding: String.Encoding.utf8)
+           // print("Json String  \(jsonString)" )
 			return .success(result, jsonString)
+            
 		} catch {
 			return .failure(apiResponse?.code, VirtusizeError.jsonDecodingFailed(String(describing: type), error))
 		}


### PR DESCRIPTION
…nctions/size-rec/get-size ➝ https://size-recommendation.virtusize.jp/item

- Refactor: Change the get-size endpoint from https://services.virtusize.jp/ds-functions/size-rec/get-size ➝ https://size-recommendation.virtusize.jp/item
- Refactor: Change in request body of VirtusizeGetSizeParams: Remove "modelInfo" key,  in "gender" now getting value from VirtusizeUserBodyProfile
- Refactor: Change in Responce Model of BodyProfileRecommendedSize
- Docs: Update Readme file to update pod version

|

### Ticket

https://app.clickup.com/t/3702259/NSDK-177