### PR TITLE
[NSDK-181] Update current privacy manifest

### DIFF
--- a/.github/workflows/pull-request-checks.yml
+++ b/.github/workflows/pull-request-checks.yml
@@ -20,7 +20,9 @@ jobs:
         uses: actions/checkout@v4
       - name: Update CocoaPods Specs
         run: pod repo update
-      - name: Swift Lint
+      - name: Install SwiftLint
+        run: brew install swiftlint
+      - name: Run SwiftLint
         run: swiftlint
       - name: Pod Lint for VirtusizeCore
         run: pod lib lint VirtusizeCore.podspec --allow-warnings

--- a/Example/Example.xcodeproj/project.pbxproj
+++ b/Example/Example.xcodeproj/project.pbxproj
@@ -368,20 +368,17 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "Apple Development";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
-				CODE_SIGN_STYLE = Manual;
+				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = "";
-				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 4R67Q8JL33;
 				INFOPLIST_FILE = "$(SRCROOT)/Sources/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = Bacancy.virtusizeDemoApp.com;
+				PRODUCT_BUNDLE_IDENTIFIER = com.example.Virtusize;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
-				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = virtusizeDemoApp_dist;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 1;
 			};
@@ -392,20 +389,17 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "Apple Development";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
-				CODE_SIGN_STYLE = Manual;
+				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = "";
-				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 4R67Q8JL33;
 				INFOPLIST_FILE = "$(SRCROOT)/Sources/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = Bacancy.virtusizeDemoApp.com;
+				PRODUCT_BUNDLE_IDENTIFIER = com.example.Virtusize;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
-				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = virtusizeDemoApp_dist;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 1;
 			};

--- a/Example/Example.xcodeproj/project.pbxproj
+++ b/Example/Example.xcodeproj/project.pbxproj
@@ -376,7 +376,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.example.Virtusize;
+				PRODUCT_BUNDLE_IDENTIFIER = com.virtusize.Example;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_VERSION = 5.0;
@@ -397,7 +397,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.example.Virtusize;
+				PRODUCT_BUNDLE_IDENTIFIER = com.virtusize.Example;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_VERSION = 5.0;

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ build:
 		-workspace "Virtusize.xcworkspace" \
 		-scheme "Virtusize" \
 		-sdk "iphonesimulator" \
-		-destination "platform=iOS Simulator,name=iPhone 8,OS=latest"
+		-destination "platform=iOS Simulator,name=iPhone SE (3rd generation),OS=latest"
 
 virtusize-test:
 
@@ -30,7 +30,7 @@ virtusize-test:
 		-workspace "Virtusize.xcworkspace" \
 		-scheme "VirtusizeTests" \
 		-sdk "iphonesimulator" \
-		-destination "platform=iOS Simulator,name=iPhone 8,OS=latest"
+		-destination "platform=iOS Simulator,name=iPhone SE (3rd generation),OS=latest"
 
 virtusize-core-test:
 
@@ -39,7 +39,7 @@ virtusize-core-test:
 		-workspace "Virtusize.xcworkspace" \
 		-scheme "VirtusizeCoreTests" \
 		-sdk "iphonesimulator" \
-		-destination "platform=iOS Simulator,name=iPhone 8,OS=latest"
+		-destination "platform=iOS Simulator,name=iPhone SE (3rd generation),OS=latest"
 
 clean:
 

--- a/Virtusize/Sources/Resources/PrivacyInfo.xcprivacy
+++ b/Virtusize/Sources/Resources/PrivacyInfo.xcprivacy
@@ -65,14 +65,6 @@
 				<string>CA92.1</string>
 			</array>
 		</dict>
-		<dict>
-			<key>NSPrivacyAccessedAPIType</key>
-			<string>NSPrivacyAccessedAPICategoryFileTimestamp</string>
-			<key>NSPrivacyAccessedAPITypeReasons</key>
-			<array>
-				<string>35F9.1</string>
-			</array>
-		</dict>
 	</array>
 	<key>NSPrivacyTracking</key>
 	<false/>


### PR DESCRIPTION
### Description

1. Removed unnecessary privacy manifest API type NSPrivacyAccessedAPICategoryFileTimestamp

References:
https://developer.apple.com/videos/play/wwdc2023/10060/
https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_use_of_required_reason_api#4278393

2. Updated the example app's bundle ID to com.virtusize.Example and the development team to None.

<img width="908" alt="Screenshot 2024-07-09 at 0 48 48" src="https://github.com/virtusize/integration_ios/assets/7802052/55def2b2-3df2-42a5-ae96-314cec976c2f">

3. Updated the build destination (iPhone 8 is too old)

<img width="1451" alt="Screenshot 2024-07-09 at 0 47 38" src="https://github.com/virtusize/integration_ios/assets/7802052/a2e11ed9-3966-4410-adc6-dde504097fc1">

4. Fixed the Github action issue regarding SwiftLint

<img width="1479" alt="Screenshot 2024-07-09 at 0 46 55" src="https://github.com/virtusize/integration_ios/assets/7802052/cdcdc983-7c7f-4119-b7b6-fd356248d649">

### Demo

None

### Ticket

https://app.clickup.com/t/3702259/NSDK-181