### PR TITLE
[NSDK-213] Update Virtusize WebView URL

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,9 @@ Use list notation, and following prefixes:
 
 ## NEXT RELEASE for Version 2.x.x
 
+### Next Release
+- Refactor: Update the Virtusize web view URL to the following format: https://static.api.virtusize.jp/a/aoyama/\(version)/sdk-webview.html
+
 ### 2.5.10
 - Fix: Google Sign In Issue
 - Fix: Update Virtusize Auth SDK 

--- a/Virtusize/Sources/Flutter/VirtusizeFlutterReposiory.swift
+++ b/Virtusize/Sources/Flutter/VirtusizeFlutterReposiory.swift
@@ -140,7 +140,7 @@ public class VirtusizeFlutterRepository: NSObject {
 		storeProduct: VirtusizeServerProduct,
 		userBodyProfile: VirtusizeUserBodyProfile
 	) -> BodyProfileRecommendedSizeArray? {
-		let response = VirtusizeAPIService.getBodyProfileRecommendedSizeAsync(
+		let response = VirtusizeAPIService.getBodyProfileRecommendedSizesAsync(
 			productTypes: productTypes,
 			storeProduct: storeProduct,
 			userBodyProfile: userBodyProfile

--- a/Virtusize/Sources/Internal/API/APIEndpoints.swift
+++ b/Virtusize/Sources/Internal/API/APIEndpoints.swift
@@ -29,7 +29,8 @@ internal enum APIEndpoints {
 	case productDataCheck(externalId: String)
 	case productMetaDataHints
 	case events
-	case virtusizeWebView
+    case latestAoyamaVersion
+	case virtusizeWebView(version: String)
 	case storeViewApiKey
 	case orders
 	case storeProducts(productId: Int)
@@ -42,6 +43,23 @@ internal enum APIEndpoints {
 	case i18n(langCode: String)
 
 	// MARK: - Properties
+    var hostname: String {
+        // swiftlint:disable switch_case_alignment
+        switch self {
+            case .productDataCheck:
+                return Virtusize.environment.servicesUrl()
+            case  .getSize:
+                return Virtusize.environment.getSizeUrl()
+        case .latestAoyamaVersion, .virtusizeWebView:
+                return Virtusize.environment.virtusizeStaticApiUrl()
+            case .i18n:
+                return Virtusize.environment.i18nUrl()
+            case .events:
+                return Virtusize.environment.eventApiUrl()
+            default:
+                return Virtusize.environment.rawValue
+        }
+    }
 
 	var components: URLComponents {
 		var components = URLComponents()
@@ -50,7 +68,6 @@ internal enum APIEndpoints {
 
 		let envPathForServicesAPI = Virtusize.environment.isProdEnv ? "" : "/stg"
 
-		// swiftlint:disable switch_case_alignment
 		switch self {
 			case .productDataCheck(let externalId):
 				components.path = "\(envPathForServicesAPI)/product/check"
@@ -62,9 +79,11 @@ internal enum APIEndpoints {
 			case .events:
 				break
 
-			case .virtusizeWebView:
-				let envPath = Virtusize.environment.isProdEnv ? "latest" : "staging"
-				components.path = "/a/aoyama/\(envPath)/sdk-webview.html"
+            case .latestAoyamaVersion:
+                components.path = "/a/aoyama/latest.txt"
+
+			case .virtusizeWebView(let version):
+				components.path = "/a/aoyama/\(version)/sdk-webview.html"
 
 			case .storeViewApiKey:
 				components.path = "/a/api/v3/stores/api-key/\(apiKey)"
@@ -98,26 +117,8 @@ internal enum APIEndpoints {
 			case .i18n(let langCode):
 				components.path = "/bundle-payloads/aoyama/\(langCode)"
 		}
-   
-		return components
-	}
 
-	var hostname: String {
-		// swiftlint:disable switch_case_alignment
-		switch self {
-			case .productDataCheck:
-				return Virtusize.environment.servicesUrl()
-            case  .getSize:
-                return Virtusize.environment.getSizeUrl()
-			case .virtusizeWebView:
-				return Virtusize.environment.virtusizeStaticApiUrl()
-			case .i18n:
-				return Virtusize.environment.i18nUrl()
-			case .events:
-				return Virtusize.environment.eventApiUrl()
-			default:
-				return Virtusize.environment.rawValue
-		}
+		return components
 	}
 
 	var apiKey: String {

--- a/Virtusize/Sources/Internal/API/VirtusizeAPIRequest.swift
+++ b/Virtusize/Sources/Internal/API/VirtusizeAPIRequest.swift
@@ -80,11 +80,20 @@ extension APIRequest {
 		return apiRequest(components: endpoint.components, withPayload: payloadData)
 	}
 
+    /// Gets the `URLRequest` for the `latestAoyamaVersion` request
+    ///
+    /// - Returns: A `URLRequest` for the `latestAoyamaVersion` request
+    internal static func fetchLatestAoyamaVersion() -> URLRequest {
+        let endpoint = APIEndpoints.latestAoyamaVersion
+        return apiRequest(components: endpoint.components)
+    }
+
 	/// Gets the `URLRequest` for the `VirtusizeWebView` request
-	///
+    /// - Parameters:
+    ///   - version: The version of Aoyama
 	/// - Returns: A `URLRequest` for the `VirtusizeWebView` request
-	internal static func virtusizeWebView() -> URLRequest? {
-		let endpoint = APIEndpoints.virtusizeWebView
+    internal static func virtusizeWebView(version: String) -> URLRequest? {
+        let endpoint = APIEndpoints.virtusizeWebView(version: version)
 		return HTTPRequest(components: endpoint.components)
 	}
 
@@ -177,25 +186,6 @@ extension APIRequest {
 		) else {
 			return nil
 		}
-/*
- Chirag: Belows Logic is for to check request Body
-        // Print JSON from data
-    do {
-     
-            if let json = try JSONSerialization.jsonObject(with: jsonData, options: []) as? [String: Any] {
-                // Convert JSON object back to Data for pretty printing
-                let prettyPrintedData = try JSONSerialization.data(withJSONObject: json, options: .prettyPrinted)
-                
-                // Convert the Data to a string
-                if let prettyPrintedString = String(data: prettyPrintedData, encoding: .utf8) {
-                    print(prettyPrintedString)
-                }
-            }
-        } catch {
-            print("Error converting JSON data to string: \(error.localizedDescription)")
-        }
-   */
-       
 		return apiRequest(components: endpoint.components, withPayload: jsonData)
 	}
 

--- a/Virtusize/Sources/Internal/API/VirtusizeAPIService.swift
+++ b/Virtusize/Sources/Internal/API/VirtusizeAPIService.swift
@@ -165,14 +165,14 @@ class VirtusizeAPIService: APIService {
 		return getAPIResultAsync(request: request, type: VirtusizeUserBodyProfile.self)
 	}
 
-	/// The API request for retrieving the recommended size based on the user body profile
+	/// The API request for retrieving the recommended sizes based on the user body profile
 	///
 	/// - Parameters:
 	///   - productTypes: A list of product types
 	///   - storeProduct: The store product data
 	///   - userBodyProfile: the user body profile data
-	/// - Returns: the user body profile recommended size in the type of `BodyProfileRecommendedSize`
-	internal static func getBodyProfileRecommendedSizeAsync(
+	/// - Returns: the user body profile recommended size array in the type of `BodyProfileRecommendedSize`
+	internal static func getBodyProfileRecommendedSizesAsync(
 		productTypes: [VirtusizeProductType],
 		storeProduct: VirtusizeServerProduct,
 		userBodyProfile: VirtusizeUserBodyProfile

--- a/Virtusize/Sources/Internal/API/VirtusizeAPIService.swift
+++ b/Virtusize/Sources/Internal/API/VirtusizeAPIService.swift
@@ -184,10 +184,6 @@ class VirtusizeAPIService: APIService {
         else {
 			return .failure(nil)
 		}
-      
-        
-     
-        
 		return getAPIResultAsync(request: request, type: BodyProfileRecommendedSizeArray.self)
 	}
 
@@ -225,4 +221,18 @@ class VirtusizeAPIService: APIService {
 		}
 		return .success(image, nil)
 	}
+
+    // The API request for fetching the latest version of Aoyama from a txt URL
+    ///
+    /// - Returns: the version in `String`
+    internal static func fetchLatestAoyamaVersion() -> APIResult<String> {
+        let request = APIRequest.fetchLatestAoyamaVersion()
+        let apiResponse = VirtusizeAPIService.performAsync(request)
+        guard let data = apiResponse?.data,
+              let version = String(data: data, encoding: .utf8) else {
+            return .failure(apiResponse?.code, apiResponse?.virtusizeError)
+        }
+        let trimmedVersion = version.trimmingCharacters(in: .whitespacesAndNewlines)
+        return .success(trimmedVersion, nil)
+    }
 }

--- a/Virtusize/Sources/Models/BodyProfileRecommendedSize.swift
+++ b/Virtusize/Sources/Models/BodyProfileRecommendedSize.swift
@@ -23,8 +23,6 @@
 //
 
 /// This structure represents the response for the recommendation API based on the user body profile
-
-
 public struct BodyProfileRecommendedSize: Codable {
     let extProductId : String?
     let sizeName : String?
@@ -53,34 +51,31 @@ public struct BodyProfileRecommendedSize: Codable {
     }
     // swiftlint:enable line_length
 }
+
 public typealias BodyProfileRecommendedSizeArray = [BodyProfileRecommendedSize]
+
 // MARK: - VirtualItem
 struct VirtualItem: Codable {
-    let bust : Double?
-    let waist : Double?
-    let hip : Double?
+    let bust: Double?
+    let waist: Double?
+    let hip: Double?
     let inseam: String?
     let sleeve: String?
 }
 
 // MARK: - WillFitForSizes
 struct WillFitForSizes: Codable {
-    let large : Bool?
-    let  medium  : Bool?
+    let large: Bool?
+    let medium: Bool?
     let extraSmall: Bool?
     let extraLarge: Bool?
     let small: Bool?
-    
-    
-    enum CodingKeys: String, CodingKey {
 
+    enum CodingKeys: String, CodingKey {
         case large = "large"
         case medium = "medium"
         case extraSmall = "extra small"
         case extraLarge = "extra large"
         case small = "small"
-        
     }
 }
-
-

--- a/Virtusize/Sources/UI/VirtusizeWebViewController.swift
+++ b/Virtusize/Sources/UI/VirtusizeWebViewController.swift
@@ -117,11 +117,11 @@ public final class VirtusizeWebViewController: UIViewController {
 			NSLayoutConstraint.activate(verticalConstraints + horizontalConstraints)
 		}
 
-		// If the request is invalid, the controller should be dismissed
-		guard let request = APIRequest.virtusizeWebView() else {
-			reportError(error: .invalidRequest)
-			return
-		}
+        guard let version = VirtusizeAPIService.fetchLatestAoyamaVersion().success,
+              let request = APIRequest.virtusizeWebView(version: version) else {
+            reportError(error: .invalidRequest)
+            return
+        }
 		webView.load(request)
 	}
 

--- a/Virtusize/Sources/UI/VirtusizeWebViewController.swift
+++ b/Virtusize/Sources/UI/VirtusizeWebViewController.swift
@@ -117,6 +117,7 @@ public final class VirtusizeWebViewController: UIViewController {
 			NSLayoutConstraint.activate(verticalConstraints + horizontalConstraints)
 		}
 
+        // If the request is invalid, the controller should be dismissed
         guard let version = VirtusizeAPIService.fetchLatestAoyamaVersion().success,
               let request = APIRequest.virtusizeWebView(version: version) else {
             reportError(error: .invalidRequest)

--- a/Virtusize/Sources/VirtusizeConfiguration.swift
+++ b/Virtusize/Sources/VirtusizeConfiguration.swift
@@ -26,4 +26,5 @@ import Foundation
 
 struct VirtusizeConfiguration {
 	static let SDKVersion = "2.5.10"
+    static let defaultAoyamaVersion = "3.2.6"
 }

--- a/Virtusize/Sources/VirtusizeRepository.swift
+++ b/Virtusize/Sources/VirtusizeRepository.swift
@@ -45,7 +45,7 @@ internal class VirtusizeRepository: NSObject {
 	private var userProducts: [VirtusizeServerProduct]?
 	private var userBodyProfile: VirtusizeUserBodyProfile?
 	private var sizeComparisonRecommendedSize: SizeComparisonRecommendedSize?
-	private var bodyProfileRecommendedSize: BodyProfileRecommendedSizeArray?
+	private var bodyProfileRecommendedSizes: BodyProfileRecommendedSizeArray?
 
 	/// A set to cache the store product information of all the visited products
 	private var serverStoreProductSet: Set<VirtusizeServerProduct> = []
@@ -192,7 +192,7 @@ internal class VirtusizeRepository: NSObject {
  		}
 
 		if let userBodyProfile = userBodyProfile {
-			bodyProfileRecommendedSize = VirtusizeAPIService.getBodyProfileRecommendedSizeAsync(
+			bodyProfileRecommendedSizes = VirtusizeAPIService.getBodyProfileRecommendedSizesAsync(
 				productTypes: productTypes!,
 				storeProduct: storeProduct!,
 				userBodyProfile: userBodyProfile
@@ -217,7 +217,7 @@ internal class VirtusizeRepository: NSObject {
 		userProducts = nil
 		sizeComparisonRecommendedSize = nil
 		userBodyProfile = nil
-		bodyProfileRecommendedSize = nil
+		bodyProfileRecommendedSizes = nil
 	}
 
 	/// Updates the user session by calling the session API
@@ -268,9 +268,9 @@ internal class VirtusizeRepository: NSObject {
 			case .compareProduct:
 				Virtusize.sizeRecData = (product, sizeComparisonRecommendedSize, nil)
 			case .body:
-            Virtusize.sizeRecData = (product, nil, bodyProfileRecommendedSize?[0])
+            Virtusize.sizeRecData = (product, nil, bodyProfileRecommendedSizes?.first)
 			default:
-            Virtusize.sizeRecData = (product, sizeComparisonRecommendedSize, bodyProfileRecommendedSize?[0])
+            Virtusize.sizeRecData = (product, sizeComparisonRecommendedSize, bodyProfileRecommendedSizes?.first)
 		}
 	}
 
@@ -281,7 +281,7 @@ internal class VirtusizeRepository: NSObject {
 		guard let recommendedSize = recommendedSize else {
 			return
 		}
-        bodyProfileRecommendedSize?.append(BodyProfileRecommendedSize(sizeName: recommendedSize))
+        bodyProfileRecommendedSizes?.append(BodyProfileRecommendedSize(sizeName: recommendedSize))
 	}
 
 	/// Removes the deleted user product by the product ID from the user product list

--- a/Virtusize/Sources/VirtusizeRepository.swift
+++ b/Virtusize/Sources/VirtusizeRepository.swift
@@ -192,15 +192,11 @@ internal class VirtusizeRepository: NSObject {
  		}
 
 		if let userBodyProfile = userBodyProfile {
-            
 			bodyProfileRecommendedSize = VirtusizeAPIService.getBodyProfileRecommendedSizeAsync(
 				productTypes: productTypes!,
 				storeProduct: storeProduct!,
 				userBodyProfile: userBodyProfile
 			).success
-            
-        
-            
 		}
 
 		var userProducts = self.userProducts ?? []
@@ -286,7 +282,6 @@ internal class VirtusizeRepository: NSObject {
 			return
 		}
         bodyProfileRecommendedSize?.append(BodyProfileRecommendedSize(sizeName: recommendedSize))
-		
 	}
 
 	/// Removes the deleted user product by the product ID from the user product list

--- a/Virtusize/Tests/APIEndpointsTests.swift
+++ b/Virtusize/Tests/APIEndpointsTests.swift
@@ -72,6 +72,13 @@ class APIEndpointsTests: XCTestCase {
 
         XCTAssertNil(endpoint.components.queryItems)
     }
+    
+    func testLatestAoyamaVersionEndpoint_returnExpectedComponents() {
+        let endpoint = APIEndpoints.latestAoyamaVersion
+
+        XCTAssertEqual(endpoint.components.host, "static.api.virtusize.com")
+        XCTAssertEqual(endpoint.components.path, "/a/aoyama/latest.txt")
+    }
 
     func testVirtusizeWebViewEndpoint_japanEnv_returnExpectedComponents() {
         Virtusize.environment = .JAPAN
@@ -175,7 +182,7 @@ class APIEndpointsTests: XCTestCase {
 
         XCTAssertNil(endpoint.components.queryItems)
     }
-    
+
     private func getQueryParametersDict(queryItems: [URLQueryItem]?) -> [String: String] {
         guard let items = queryItems else {
             return [:]

--- a/Virtusize/Tests/APIEndpointsTests.swift
+++ b/Virtusize/Tests/APIEndpointsTests.swift
@@ -76,11 +76,11 @@ class APIEndpointsTests: XCTestCase {
     func testVirtusizeWebViewEndpoint_japanEnv_returnExpectedComponents() {
         Virtusize.environment = .JAPAN
 
-        let endpoint = APIEndpoints.virtusizeWebView
+        let endpoint = APIEndpoints.virtusizeWebView(version: "3.2.6")
 
         XCTAssertEqual(endpoint.components.host, "static.api.virtusize.jp")
 
-		XCTAssertEqual(endpoint.components.path, "/a/aoyama/latest/sdk-webview.html")
+		XCTAssertEqual(endpoint.components.path, "/a/aoyama/3.2.6/sdk-webview.html")
 
         XCTAssertNil(endpoint.components.queryItems)
     }
@@ -88,10 +88,10 @@ class APIEndpointsTests: XCTestCase {
 	func testVirtusizeWebViewEndpoint_stagingEnv_returnExpectedComponents() {
 		Virtusize.environment = .STAGING
 
-		let endpoint = APIEndpoints.virtusizeWebView
+		let endpoint = APIEndpoints.virtusizeWebView(version: "3.2.6")
 
 		XCTAssertEqual(endpoint.components.host, "static.api.virtusize.com")
-		XCTAssertEqual(endpoint.components.path, "/a/aoyama/staging/sdk-webview.html")
+		XCTAssertEqual(endpoint.components.path, "/a/aoyama/3.2.6/sdk-webview.html")
 
 		XCTAssertNil(endpoint.components.queryItems)
 	}

--- a/Virtusize/Tests/APIEndpointsTests.swift
+++ b/Virtusize/Tests/APIEndpointsTests.swift
@@ -76,11 +76,11 @@ class APIEndpointsTests: XCTestCase {
     func testVirtusizeWebViewEndpoint_japanEnv_returnExpectedComponents() {
         Virtusize.environment = .JAPAN
 
-        let endpoint = APIEndpoints.virtusizeWebView(version: "3.2.6")
+        let endpoint = APIEndpoints.virtusizeWebView(version: VirtusizeConfiguration.defaultAoyamaVersion)
 
         XCTAssertEqual(endpoint.components.host, "static.api.virtusize.jp")
 
-		XCTAssertEqual(endpoint.components.path, "/a/aoyama/3.2.6/sdk-webview.html")
+		XCTAssertEqual(endpoint.components.path, "/a/aoyama/\(VirtusizeConfiguration.defaultAoyamaVersion)/sdk-webview.html")
 
         XCTAssertNil(endpoint.components.queryItems)
     }
@@ -88,10 +88,10 @@ class APIEndpointsTests: XCTestCase {
 	func testVirtusizeWebViewEndpoint_stagingEnv_returnExpectedComponents() {
 		Virtusize.environment = .STAGING
 
-		let endpoint = APIEndpoints.virtusizeWebView(version: "3.2.6")
+		let endpoint = APIEndpoints.virtusizeWebView(version: VirtusizeConfiguration.defaultAoyamaVersion)
 
 		XCTAssertEqual(endpoint.components.host, "static.api.virtusize.com")
-		XCTAssertEqual(endpoint.components.path, "/a/aoyama/3.2.6/sdk-webview.html")
+		XCTAssertEqual(endpoint.components.path, "/a/aoyama/\(VirtusizeConfiguration.defaultAoyamaVersion)/sdk-webview.html")
 
 		XCTAssertNil(endpoint.components.queryItems)
 	}

--- a/Virtusize/Tests/APIRequestTests.swift
+++ b/Virtusize/Tests/APIRequestTests.swift
@@ -37,6 +37,17 @@ class APIRequestTests: XCTestCase {
     override func tearDownWithError() throws {
         // Put teardown code here. This method is called after the invocation of each test method in the class.
     }
+    
+    func testVirtusizeWebView_expectedApiRequest() {
+        let apiRequest = APIRequest.virtusizeWebView(version: VirtusizeConfiguration.defaultAoyamaVersion)
+
+        XCTAssertEqual(apiRequest?.httpMethod, APIMethod.get.rawValue)
+        XCTAssertNil(apiRequest?.httpBody)
+        XCTAssertEqual(
+            apiRequest?.url?.absoluteString,
+            "https://static.api.virtusize.com/a/aoyama/\(VirtusizeConfiguration.defaultAoyamaVersion)/sdk-webview.html"
+        )
+    }
 
     func testRetrieveStoreInfo_expectedHeaders() {
         let apiRequest = APIRequest.retrieveStoreInfo()

--- a/Virtusize/Tests/VirtusizeAPIServiceTests.swift
+++ b/Virtusize/Tests/VirtusizeAPIServiceTests.swift
@@ -35,6 +35,27 @@ class VirtusizeAPIServiceTests: XCTestCase {
         Virtusize.environment = .STAGING
     }
 
+    func testFetchLatestAoyamaVersion() {
+        let expectation = self.expectation(description: "Virtusize.fetchLatestAoyamaVersion reaches the callback")
+        var actualVersion: String?
+        DispatchQueue.global().async {
+
+            actualVersion = VirtusizeAPIService.fetchLatestAoyamaVersion().success
+
+            DispatchQueue.main.async {
+                expectation.fulfill()
+            }
+        }
+
+        waitForExpectations(timeout: 5) { error in
+            if let error = error {
+                XCTFail("waitForExpectations error: \(error)")
+            }
+        }
+
+        XCTAssertEqual(actualVersion, VirtusizeConfiguration.defaultAoyamaVersion)
+    }
+
     func testProductDataCheck_hasExpectedCallbackData() {
         let expectation = self.expectation(description: "Virtusize.productCheck reaches the callback")
         var actualProduct: VirtusizeProduct?
@@ -42,9 +63,9 @@ class VirtusizeAPIServiceTests: XCTestCase {
                                                      urlResponse: nil,
                                                      error: nil)
         DispatchQueue.global().async {
-            
+
             actualProduct = VirtusizeAPIService.productCheckAsync(product: TestFixtures.virtusizeProduct).success
-            
+
             DispatchQueue.main.async {
                 expectation.fulfill()
             }
@@ -403,7 +424,7 @@ class VirtusizeAPIServiceTests: XCTestCase {
         )
 
         DispatchQueue.global().async {
- 
+
             actualError = VirtusizeAPIService.getUserProductsAsync().failure
 
             DispatchQueue.main.async {

--- a/Virtusize/Tests/VirtusizeAPIServiceTests.swift
+++ b/Virtusize/Tests/VirtusizeAPIServiceTests.swift
@@ -617,7 +617,7 @@ class VirtusizeAPIServiceTests: XCTestCase {
 
     func testGetUserBodyRecommendedSize() {
         let expectation = self.expectation(description: "Virtusize.getUserBodyRecommendedSize reaches the callback")
-        var actualRecommendedSizes: [BodyProfileRecommendedSize]?
+        var actualRecommendedSizes: BodyProfileRecommendedSizeArray?
 
         VirtusizeAPIService.session = MockURLSession(
             data: "[{\"sizeName\": \"35\"}]".data(using: .utf8),
@@ -626,7 +626,7 @@ class VirtusizeAPIServiceTests: XCTestCase {
         )
 
         DispatchQueue.global().async {
-            actualRecommendedSizes = VirtusizeAPIService.getBodyProfileRecommendedSizeAsync(
+            actualRecommendedSizes = VirtusizeAPIService.getBodyProfileRecommendedSizesAsync(
                 productTypes: TestFixtures.getProductTypes(),
                 storeProduct: TestFixtures.getStoreProduct(gender: "female")!,
                 userBodyProfile: TestFixtures.getUserBodyProfile()!
@@ -644,7 +644,7 @@ class VirtusizeAPIServiceTests: XCTestCase {
         }
 
         XCTAssertNotNil(actualRecommendedSizes)
-        XCTAssertEqual(actualRecommendedSizes?[0].sizeName, "35")
+        XCTAssertEqual(actualRecommendedSizes?.first?.sizeName, "35")
     }
 }
 

--- a/Virtusize/Tests/VirtusizeAPIServiceTests.swift
+++ b/Virtusize/Tests/VirtusizeAPIServiceTests.swift
@@ -24,7 +24,6 @@
 
 import XCTest
 @testable import Virtusize
-/*
 @testable import VirtusizeCore
 
 // swiftlint:disable type_body_length file_length
@@ -33,23 +32,23 @@ class VirtusizeAPIServiceTests: XCTestCase {
     override func setUpWithError() throws {
         Virtusize.APIKey = TestFixtures.apiKey
         Virtusize.userID = "123"
-        Virtusize.environment = .staging
+        Virtusize.environment = .STAGING
     }
 
     func testProductDataCheck_hasExpectedCallbackData() {
         let expectation = self.expectation(description: "Virtusize.productCheck reaches the callback")
-		var actualProduct: VirtusizeProduct?
+        var actualProduct: VirtusizeProduct?
         VirtusizeAPIService.session = MockURLSession(data: TestFixtures.productDataCheckJsonResponse.data(using: .utf8),
-                                           urlResponse: nil,
-                                           error: nil)
-		DispatchQueue.global().async {
-
-			actualProduct = VirtusizeAPIService.productCheckAsync(product: TestFixtures.virtusizeProduct).success
-
-			DispatchQueue.main.async {
-				expectation.fulfill()
-			}
-		}
+                                                     urlResponse: nil,
+                                                     error: nil)
+        DispatchQueue.global().async {
+            
+            actualProduct = VirtusizeAPIService.productCheckAsync(product: TestFixtures.virtusizeProduct).success
+            
+            DispatchQueue.main.async {
+                expectation.fulfill()
+            }
+        }
 
         waitForExpectations(timeout: 5) { error in
             if let error = error {
@@ -73,10 +72,10 @@ class VirtusizeAPIServiceTests: XCTestCase {
     func testSendProductImage_hasExpectedCallbackData() {
         let expectation = self.expectation(description: "Virtusize.sendProductImage reaches the callback")
         var actualObject: JSONObject?
-		VirtusizeAPIService.session = MockURLSession(data: TestFixtures.productMetaDataHintsJsonResponse.data(using: .utf8),
-                                           urlResponse: nil,
-                                           error: nil)
-		VirtusizeAPIService.sendProductImage(of: TestFixtures.virtusizeProduct, forStore: 2) { jsonObject in
+        VirtusizeAPIService.session = MockURLSession(data: TestFixtures.productMetaDataHintsJsonResponse.data(using: .utf8),
+                                                     urlResponse: nil,
+                                                     error: nil)
+        VirtusizeAPIService.sendProductImage(of: TestFixtures.virtusizeProduct, forStore: 2) { jsonObject in
             actualObject = jsonObject
             expectation.fulfill()
         }
@@ -96,19 +95,19 @@ class VirtusizeAPIServiceTests: XCTestCase {
     func testSendEvent_UserSawProduct_hasExpectedCallbackData() {
         let expectation = self.expectation(description: "Virtusize.sendEvent reaches the callback")
         var actualObject: JSONObject?
-		VirtusizeAPIService.session = MockURLSession(
-			data: TestFixtures.sendEventUserSawProductJsonResponse.data(using: .utf8),
-			urlResponse: nil,
-			error: nil
-		)
+        VirtusizeAPIService.session = MockURLSession(
+            data: TestFixtures.sendEventUserSawProductJsonResponse.data(using: .utf8),
+            urlResponse: nil,
+            error: nil
+        )
 
-		VirtusizeAPIService.sendEvent(
+        VirtusizeAPIService.sendEvent(
             VirtusizeEvent(name: "user-saw-product",
                            data: nil),
             withContext: nil) { jsonObject in
                 actualObject = jsonObject
                 expectation.fulfill()
-        }
+            }
 
         waitForExpectations(timeout: 5) { error in
             if let error = error {
@@ -124,18 +123,18 @@ class VirtusizeAPIServiceTests: XCTestCase {
     func testRetrieveFullStoreInfo_success_hasExpectedRegion() {
         let expectation = self.expectation(description: "Virtusize.retrieveStoreInfo reaches the callback")
         var actualRegion: String?
-		VirtusizeAPIService.session = MockURLSession(data: TestFixtures.fullStoreInfoJsonResponse.data(using: .utf8),
-                                                  urlResponse: nil,
-                                                  error: nil)
+        VirtusizeAPIService.session = MockURLSession(data: TestFixtures.fullStoreInfoJsonResponse.data(using: .utf8),
+                                                     urlResponse: nil,
+                                                     error: nil)
 
-		DispatchQueue.global().async {
+        DispatchQueue.global().async {
 
-			actualRegion = VirtusizeAPIService.retrieveStoreInfoAsync().success?.region
+            actualRegion = VirtusizeAPIService.retrieveStoreInfoAsync().success?.region
 
-			DispatchQueue.main.async {
-				expectation.fulfill()
-			}
-		}
+            DispatchQueue.main.async {
+                expectation.fulfill()
+            }
+        }
 
         waitForExpectations(timeout: 5) { error in
             if let error = error {
@@ -149,19 +148,19 @@ class VirtusizeAPIServiceTests: XCTestCase {
     func testRetrieveStoreInfoWithSomeNullValues_success_hasExpectedRegion() {
         let expectation = self.expectation(description: "Virtusize.retrieveStoreInfo reaches the callback")
         var actualRegion: String?
-		VirtusizeAPIService.session = MockURLSession(
+        VirtusizeAPIService.session = MockURLSession(
             data: TestFixtures.storeInfoWithSomeNullValuesJsonResponse.data(using: .utf8),
             urlResponse: nil,
             error: nil)
 
-		DispatchQueue.global().async {
+        DispatchQueue.global().async {
 
-			actualRegion = VirtusizeAPIService.retrieveStoreInfoAsync().success?.region
+            actualRegion = VirtusizeAPIService.retrieveStoreInfoAsync().success?.region
 
-			DispatchQueue.main.async {
-				expectation.fulfill()
-			}
-		}
+            DispatchQueue.main.async {
+                expectation.fulfill()
+            }
+        }
 
         waitForExpectations(timeout: 5) { error in
             if let error = error {
@@ -177,22 +176,22 @@ class VirtusizeAPIServiceTests: XCTestCase {
         let expectation = self.expectation(description: "Virtusize.retrieveStoreInfo reaches the callback")
         var actualError: VirtusizeError?
 
-		let requestURL = "https://staging.virtusize.com/a/api/v3/stores/api-key/\(Virtusize.APIKey!)?format=json"
-		let response = HTTPURLResponse(url: URL(string: requestURL)!, statusCode: 403, httpVersion: nil, headerFields: nil)
-		VirtusizeAPIService.session = MockURLSession(
-			data: TestFixtures.retrieveStoreInfoErrorJsonResponse.data(using: .utf8),
-			urlResponse: response,
-			error: nil
-		)
+        let requestURL = "https://staging.virtusize.com/a/api/v3/stores/api-key/\(Virtusize.APIKey!)?format=json"
+        let response = HTTPURLResponse(url: URL(string: requestURL)!, statusCode: 403, httpVersion: nil, headerFields: nil)
+        VirtusizeAPIService.session = MockURLSession(
+            data: TestFixtures.retrieveStoreInfoErrorJsonResponse.data(using: .utf8),
+            urlResponse: response,
+            error: nil
+        )
 
-		DispatchQueue.global().async {
+        DispatchQueue.global().async {
 
-			actualError = VirtusizeAPIService.retrieveStoreInfoAsync().failure
+            actualError = VirtusizeAPIService.retrieveStoreInfoAsync().failure
 
-			DispatchQueue.main.async {
-				expectation.fulfill()
-			}
-		}
+            DispatchQueue.main.async {
+                expectation.fulfill()
+            }
+        }
 
         waitForExpectations(timeout: 5) { error in
             if let error = error {
@@ -201,33 +200,33 @@ class VirtusizeAPIServiceTests: XCTestCase {
         }
 
         XCTAssertNotNil(actualError)
-		XCTAssertEqual(
-			actualError!.debugDescription,
-			VirtusizeError.apiRequestError(
-				URL(string: requestURL)!,
-				TestFixtures.retrieveStoreInfoErrorJsonResponse).debugDescription
-		)
+        XCTAssertEqual(
+            actualError!.debugDescription,
+            VirtusizeError.apiRequestError(
+                URL(string: requestURL)!,
+                TestFixtures.retrieveStoreInfoErrorJsonResponse).debugDescription
+        )
     }
 
     func testSendOrder_withValidOrder_hasSuccessCallback() {
         let expectation = self.expectation(description: "Virtusize.sendOrder reaches the callback")
         var isSuccessful: Bool = false
 
-		VirtusizeAPIService.session = MockURLSession(data: nil,
-                                           urlResponse: nil,
-                                           error: nil)
+        VirtusizeAPIService.session = MockURLSession(data: nil,
+                                                     urlResponse: nil,
+                                                     error: nil)
 
         TestFixtures.virtusizeOrder.externalUserId = "123"
         TestFixtures.virtusizeOrder.region = "JP"
 
-		DispatchQueue.global().async {
+        DispatchQueue.global().async {
 
-			isSuccessful = VirtusizeAPIService.sendOrderWithRegionAsync(TestFixtures.virtusizeOrder).isSuccessful
+            isSuccessful = VirtusizeAPIService.sendOrderWithRegionAsync(TestFixtures.virtusizeOrder).isSuccessful
 
-			DispatchQueue.main.async {
-				expectation.fulfill()
-			}
-		}
+            DispatchQueue.main.async {
+                expectation.fulfill()
+            }
+        }
 
         waitForExpectations(timeout: 5) { error in
             if let error = error {
@@ -242,7 +241,7 @@ class VirtusizeAPIServiceTests: XCTestCase {
         let expectation = self.expectation(description: "Virtusize.getStoreProductInfo reaches the callback")
         var actualStoreProduct: VirtusizeServerProduct?
 
-		VirtusizeAPIService.session = MockURLSession(
+        VirtusizeAPIService.session = MockURLSession(
             data: TestFixtures.getStoreProductJsonResponse(gender: nil).data(using: .utf8),
             urlResponse: nil,
             error: nil
@@ -289,11 +288,11 @@ class VirtusizeAPIServiceTests: XCTestCase {
         let expectation = self.expectation(description: "Virtusize.getStoreProductInfo reaches the callback")
         var virtusizeError: VirtusizeError?
 
-		VirtusizeAPIService.session = MockURLSession(
-                   data: TestFixtures.notFoundResponse.data(using: .utf8),
-                   urlResponse: notFoundURLResponse,
-                   error: nil
-               )
+        VirtusizeAPIService.session = MockURLSession(
+            data: TestFixtures.notFoundResponse.data(using: .utf8),
+            urlResponse: notFoundURLResponse,
+            error: nil
+        )
 
         DispatchQueue.global().async {
 
@@ -318,7 +317,7 @@ class VirtusizeAPIServiceTests: XCTestCase {
         let expectation = self.expectation(description: "Virtusize.getUserProducts reaches the callback")
         var actualUserProductList: [VirtusizeServerProduct]?
 
-		VirtusizeAPIService.session = MockURLSession(
+        VirtusizeAPIService.session = MockURLSession(
             data: TestFixtures.userProductArrayJsonResponse.data(using: .utf8),
             urlResponse: nil,
             error: nil
@@ -363,7 +362,7 @@ class VirtusizeAPIServiceTests: XCTestCase {
         let expectation = self.expectation(description: "Virtusize.getUserProducts reaches the callback")
         var actualUserProductList: [VirtusizeServerProduct]?
 
-		VirtusizeAPIService.session = MockURLSession(
+        VirtusizeAPIService.session = MockURLSession(
             data: TestFixtures.emptyProductArrayJsonResponse.data(using: .utf8),
             urlResponse: nil,
             error: nil
@@ -397,14 +396,14 @@ class VirtusizeAPIServiceTests: XCTestCase {
                                                   httpVersion: nil,
                                                   headerFields: [:])!
 
-		VirtusizeAPIService.session = MockURLSession(
+        VirtusizeAPIService.session = MockURLSession(
             data: TestFixtures.wardrobeNotFoundErrorJsonResponse.data(using: .utf8),
             urlResponse: notFoundURLResponse,
             error: nil
         )
 
         DispatchQueue.global().async {
-
+ 
             actualError = VirtusizeAPIService.getUserProductsAsync().failure
 
             DispatchQueue.main.async {
@@ -426,7 +425,7 @@ class VirtusizeAPIServiceTests: XCTestCase {
         let expectation = self.expectation(description: "Virtusize.getStoreProductInfo reaches the callback")
         var actualProductTypes: [VirtusizeProductType] = []
 
-		VirtusizeAPIService.session = MockURLSession(
+        VirtusizeAPIService.session = MockURLSession(
             data: TestFixtures.productTypeArrayJsonResponse.data(using: .utf8),
             urlResponse: nil,
             error: nil
@@ -458,7 +457,7 @@ class VirtusizeAPIServiceTests: XCTestCase {
         let expectation = self.expectation(description: "Virtusize.getI18nTexts reaches the callback")
         var actualI18nLocalization: VirtusizeI18nLocalization?
 
-		VirtusizeAPIService.session = MockURLSession(
+        VirtusizeAPIService.session = MockURLSession(
             data: TestUtils.shared.loadTestJsonFile(jsonFileName: "i18n_ko"),
             urlResponse: nil,
             error: nil
@@ -495,7 +494,7 @@ class VirtusizeAPIServiceTests: XCTestCase {
         let expectation = self.expectation(description: "Virtusize.getUserBodyProfile reaches the callback")
         var actualUserBodyProfile: VirtusizeUserBodyProfile?
 
-		VirtusizeAPIService.session = MockURLSession(
+        VirtusizeAPIService.session = MockURLSession(
             data: TestFixtures.userBodyProfileFixture,
             urlResponse: nil,
             error: nil
@@ -552,7 +551,7 @@ class VirtusizeAPIServiceTests: XCTestCase {
         let expectation = self.expectation(description: "Virtusize.getUserBodyProfile reaches the callback")
         var actualUserBodyProfile: VirtusizeUserBodyProfile?
 
-		VirtusizeAPIService.session = MockURLSession(
+        VirtusizeAPIService.session = MockURLSession(
             data: TestFixtures.emptyUserBodyProfileFixture,
             urlResponse: nil,
             error: nil
@@ -591,7 +590,7 @@ class VirtusizeAPIServiceTests: XCTestCase {
                                                   httpVersion: nil,
                                                   headerFields: [:])!
 
-		VirtusizeAPIService.session = MockURLSession(
+        VirtusizeAPIService.session = MockURLSession(
             data: TestFixtures.wardrobeNotFoundErrorJsonResponse.data(using: .utf8),
             urlResponse: notFoundURLResponse,
             error: nil
@@ -618,17 +617,16 @@ class VirtusizeAPIServiceTests: XCTestCase {
 
     func testGetUserBodyRecommendedSize() {
         let expectation = self.expectation(description: "Virtusize.getUserBodyRecommendedSize reaches the callback")
-        var actualRecommendedSize: BodyProfileRecommendedSize?
+        var actualRecommendedSizes: [BodyProfileRecommendedSize]?
 
-		VirtusizeAPIService.session = MockURLSession(
-            data: "{\"sizeName\": \"35\"}".data(using: .utf8),
+        VirtusizeAPIService.session = MockURLSession(
+            data: "[{\"sizeName\": \"35\"}]".data(using: .utf8),
             urlResponse: nil,
             error: nil
         )
 
         DispatchQueue.global().async {
-
-            actualRecommendedSize = VirtusizeAPIService.getBodyProfileRecommendedSizeAsync(
+            actualRecommendedSizes = VirtusizeAPIService.getBodyProfileRecommendedSizeAsync(
                 productTypes: TestFixtures.getProductTypes(),
                 storeProduct: TestFixtures.getStoreProduct(gender: "female")!,
                 userBodyProfile: TestFixtures.getUserBodyProfile()!
@@ -645,8 +643,8 @@ class VirtusizeAPIServiceTests: XCTestCase {
             }
         }
 
-        XCTAssertNotNil(actualRecommendedSize)
-        XCTAssertEqual(actualRecommendedSize?.sizeName, "35")
+        XCTAssertNotNil(actualRecommendedSizes)
+        XCTAssertEqual(actualRecommendedSizes?[0].sizeName, "35")
     }
 }
 
@@ -691,4 +689,3 @@ extension VirtusizeAPIServiceTests {
         }
     }
 }
-*/

--- a/VirtusizeCore/Sources/API/APIService.swift
+++ b/VirtusizeCore/Sources/API/APIService.swift
@@ -57,17 +57,13 @@ open class APIService {
 		error errorHandler: ErrorHandler? = nil
 	) {
 		let task: URLSessionDataTask
-        
 		task = APIService.session.dataTask(with: request) { (data, response, error) in
-            
-          
 			guard error == nil else {
 				DispatchQueue.main.async {
 					errorHandler?(VirtusizeError.apiRequestError(request.url, error!.localizedDescription))
 				}
 				return
 			}
-
 			if let httpResponse = response as? HTTPURLResponse, !httpResponse.isSuccessful() {
 				var errorDebugDescription = VirtusizeError.unknownError.debugDescription
 				if let data = data {
@@ -175,9 +171,7 @@ open class APIService {
 		do {
 			let result = try JSONDecoder().decode(type!, from: data)
 			let jsonString = String(data: data, encoding: String.Encoding.utf8)
-          
 			return .success(result, jsonString)
-            
 		} catch {
 			return .failure(apiResponse?.code, VirtusizeError.jsonDecodingFailed(String(describing: type), error))
 		}


### PR DESCRIPTION
## 🔗 Related Links

- [x] [ClickUp](https://app.clickup.com/t/3702259/NSDK-213)

## ➡️ To Be

- Fetched the latest Aoyama version from https://static.api.virtusize.com/a/aoyama/latest.txt
- Updated the Virtusize web view URL to the following format: https://static.api.virtusize.jp/a/aoyama/$version/sdk-webview.html

## ☑️ Checklist

- [x] Useless comments and/or `print` etc are **removed**
- [x] Unit test are **covered**
- [ ] Code has been **deployed and tested** on STG
- [ ] ClickUp ticket status has been **updated** to `production`
- [x] Update CHANGELOG.md with the new changes
