### PR TITLE
[NSDK-220] Fix the WebView Indefinite Loading Issue

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,7 @@ Use list notation, and following prefixes:
 ### Next Release
 - Refactor: Update the Virtusize web view URL to the following format: https://static.api.virtusize.jp/a/aoyama/\(version)/sdk-webview.html
 - Feature: Add the client sepecifc Virtusize web view URL. The format is as follows: https://static.api.virtusize.jp/a/aoyama/testing/privacy-policy-phase2-vue/sdk-webview.html
+- Bugfix: Fix the issue of the web view loading indefinitely 
 
 ### 2.5.12
 - Fix: Update Virtusize Auth SDK to fix the issue of invalid PrivacyInfo.xcprivacy

--- a/Package.swift
+++ b/Package.swift
@@ -33,6 +33,6 @@ let package = Package(
             path: "VirtusizeCore/Sources",
             exclude: ["Info.plist"],
             resources: [.process("Resources")]
-        ),
+        )
     ]
 )

--- a/Virtusize.podspec
+++ b/Virtusize.podspec
@@ -18,6 +18,9 @@ Pod::Spec.new do |s|
   s.resource_bundle = { 'Virtusize' => ["Virtusize/Sources/Resources/**/*.lproj", "Virtusize/Sources/Resources/PrivacyInfo.xcprivacy"] }
 
   s.pod_target_xcconfig = { 'BUILD_LIBRARY_FOR_DISTRIBUTION' => 'YES' }
+  s.subspec 'VirtusizeCore' do |core|
+      core.source_files = ['VirtusizeCore/Sources/*.{swift, h}', 'VirtusizeCore/Sources/**/*.swift']
+      core.resource_bundle = { 'VirtusizeCore' => ['VirtusizeCore/Sources/Resources/**/*.lproj', "VirtusizeCore/Sources/Resources/PrivacyInfo.xcprivacy"] }
+  end
   s.dependency "VirtusizeAuth", "<= 1.1.5"
-  s.dependency "VirtusizeCore", "<= #{s.version}"
 end

--- a/Virtusize/Sources/Flutter/VirtusizeFlutterReposiory.swift
+++ b/Virtusize/Sources/Flutter/VirtusizeFlutterReposiory.swift
@@ -189,7 +189,7 @@ public class VirtusizeFlutterRepository: NSObject {
 	}
 
 	public func updateUserAuthData(bid: String?, auth: String?) {
-        if let bid = bid, bid != UserDefaultsHelper.current.undefinedValue {
+        if let bid = bid, bid != UserDefaultsHelper.undefinedValue {
 			UserDefaultsHelper.current.identifier = bid
 		}
 		if let auth = auth, !auth.isEmpty {

--- a/Virtusize/Sources/Flutter/VirtusizeFlutterReposiory.swift
+++ b/Virtusize/Sources/Flutter/VirtusizeFlutterReposiory.swift
@@ -189,7 +189,7 @@ public class VirtusizeFlutterRepository: NSObject {
 	}
 
 	public func updateUserAuthData(bid: String?, auth: String?) {
-        if let bid = bid, bid != UserDefaultsHelper.undefinedValue {
+        if let bid = bid, bid != VirtusizeConstants {
 			UserDefaultsHelper.current.identifier = bid
 		}
 		if let auth = auth, !auth.isEmpty {

--- a/Virtusize/Sources/Flutter/VirtusizeFlutterReposiory.swift
+++ b/Virtusize/Sources/Flutter/VirtusizeFlutterReposiory.swift
@@ -189,7 +189,7 @@ public class VirtusizeFlutterRepository: NSObject {
 	}
 
 	public func updateUserAuthData(bid: String?, auth: String?) {
-        if let bid = bid, bid != VirtusizeConstants {
+        if let bid = bid, bid != "undefined" {
 			UserDefaultsHelper.current.identifier = bid
 		}
 		if let auth = auth, !auth.isEmpty {

--- a/Virtusize/Sources/Flutter/VirtusizeFlutterReposiory.swift
+++ b/Virtusize/Sources/Flutter/VirtusizeFlutterReposiory.swift
@@ -189,7 +189,7 @@ public class VirtusizeFlutterRepository: NSObject {
 	}
 
 	public func updateUserAuthData(bid: String?, auth: String?) {
-		if let bid = bid {
+        if let bid = bid, bid != UserDefaultsHelper.current.undefinedValue {
 			UserDefaultsHelper.current.identifier = bid
 		}
 		if let auth = auth, !auth.isEmpty {

--- a/Virtusize/Sources/Flutter/VirtusizeFlutterReposiory.swift
+++ b/Virtusize/Sources/Flutter/VirtusizeFlutterReposiory.swift
@@ -189,7 +189,7 @@ public class VirtusizeFlutterRepository: NSObject {
 	}
 
 	public func updateUserAuthData(bid: String?, auth: String?) {
-        if let bid = bid, bid != "undefined" {
+        if let bid = bid, bid != UserDefaultsHelper.current.undefinedValue {
 			UserDefaultsHelper.current.identifier = bid
 		}
 		if let auth = auth, !auth.isEmpty {

--- a/Virtusize/Sources/Virtusize.swift
+++ b/Virtusize/Sources/Virtusize.swift
@@ -117,6 +117,7 @@ public class Virtusize {
 		dispatchQueue.async {
 			virtusizeRepository.checkProductValidity(product: product) { productWithPDCData in
 				if let productWithPDCData = productWithPDCData {
+                    virtusizeRepository.updateUserSession()
 					DispatchQueue.main.async {
 						NotificationCenter.default.post(
 							name: .productDataCheck,
@@ -133,7 +134,6 @@ public class Virtusize {
 							object: Virtusize.self,
 							userInfo: [NotificationKey.storeProduct: serverProduct]
 						)
-						virtusizeRepository.updateUserSession()
 						virtusizeRepository.fetchDataForInPageRecommendation(storeProduct: serverProduct)
 						virtusizeRepository.updateInPageRecommendation(product: serverProduct)
 					}

--- a/Virtusize/Sources/Virtusize.swift
+++ b/Virtusize/Sources/Virtusize.swift
@@ -111,7 +111,6 @@ public class Virtusize {
 	}
 
 	// MARK: - Methods
-
 	/// A function for clients to populate the Virtusize views by loading a product
 	public class func load(product: VirtusizeProduct) {
 		dispatchQueue.async {
@@ -128,15 +127,15 @@ public class Virtusize {
 					virtusizeRepository.fetchInitialData(
 						externalProductId: product.externalId,
 						productId: productWithPDCData.productCheckData?.productDataId
-					) { serverProduct in
-						NotificationCenter.default.post(
-							name: .storeProduct,
-							object: Virtusize.self,
-							userInfo: [NotificationKey.storeProduct: serverProduct]
-						)
-						virtusizeRepository.fetchDataForInPageRecommendation(storeProduct: serverProduct)
-						virtusizeRepository.updateInPageRecommendation(product: serverProduct)
-					}
+                    ) { serverProduct in
+                        NotificationCenter.default.post(
+                            name: .storeProduct,
+                            object: Virtusize.self,
+                            userInfo: [NotificationKey.storeProduct: serverProduct]
+                        )
+                        virtusizeRepository.fetchDataForInPageRecommendation(storeProduct: serverProduct)
+                        virtusizeRepository.updateInPageRecommendation(product: serverProduct)
+                    }
 				}
 			}
 		}

--- a/Virtusize/Sources/VirtusizeRepository.swift
+++ b/Virtusize/Sources/VirtusizeRepository.swift
@@ -246,7 +246,7 @@ internal class VirtusizeRepository: NSObject {
 	///   - bid: a browser identifier
 	///   - auth: the auth token for the session API
 	internal func updateUserAuthData(bid: String?, auth: String?) {
-        if let bid = bid, bid != UserDefaultsHelper.current.undefinedValue {
+        if let bid = bid, bid != UserDefaultsHelper.undefinedValue {
 			UserDefaultsHelper.current.identifier = bid
 		}
 		if let auth = auth, !auth.isEmpty {

--- a/Virtusize/Sources/VirtusizeRepository.swift
+++ b/Virtusize/Sources/VirtusizeRepository.swift
@@ -247,6 +247,7 @@ internal class VirtusizeRepository: NSObject {
 	///   - auth: the auth token for the session API
 	internal func updateUserAuthData(bid: String?, auth: String?) {
 		if let bid = bid {
+        if let bid = bid, bid != UserDefaultsHelper.current.undefinedValue {
 			UserDefaultsHelper.current.identifier = bid
 		}
 		if let auth = auth,

--- a/Virtusize/Sources/VirtusizeRepository.swift
+++ b/Virtusize/Sources/VirtusizeRepository.swift
@@ -122,7 +122,7 @@ internal class VirtusizeRepository: NSObject {
 	internal func fetchInitialData(
         externalProductId: String,
         productId: Int?,
-        onSuccess: @escaping (VirtusizeServerProduct) -> Void
+        onSuccess: (VirtusizeServerProduct) -> Void
     ) {
 		guard let productId = productId else {
             return

--- a/Virtusize/Sources/VirtusizeRepository.swift
+++ b/Virtusize/Sources/VirtusizeRepository.swift
@@ -122,7 +122,7 @@ internal class VirtusizeRepository: NSObject {
 	internal func fetchInitialData(
         externalProductId: String,
         productId: Int?,
-        completion: @escaping (VirtusizeServerProduct) -> Void
+        onSuccess: @escaping (VirtusizeServerProduct) -> Void
     ) {
 		guard let productId = productId else {
             return
@@ -149,7 +149,7 @@ internal class VirtusizeRepository: NSObject {
             return
 		}
 
-        completion(storeProduct)
+        onSuccess(storeProduct)
 	}
 
 	/// Fetches data for InPage recommendation

--- a/Virtusize/Sources/VirtusizeRepository.swift
+++ b/Virtusize/Sources/VirtusizeRepository.swift
@@ -120,36 +120,36 @@ internal class VirtusizeRepository: NSObject {
 	///   - productId: the product ID from the Virtusize server
 	///   - onSuccess: the closure is called if the data from the server is successfully fetched
 	internal func fetchInitialData(
-		externalProductId: String,
-		productId: Int?,
-		onSuccess: (VirtusizeServerProduct
-		) -> Void) {
+        externalProductId: String,
+        productId: Int?,
+        completion: @escaping (VirtusizeServerProduct) -> Void
+    ) {
 		guard let productId = productId else {
-			return
+            return
 		}
 
 		let serverStoreProduct = VirtusizeAPIService.getStoreProductInfoAsync(productId: productId).success
 
-		if serverStoreProduct == nil {
+		guard let storeProduct = serverStoreProduct else {
 			Virtusize.inPageError = (true, externalProductId)
-			return
+            return
 		}
 
-		self.serverStoreProductSet.insert(serverStoreProduct!)
+		self.serverStoreProductSet.insert(storeProduct)
 
 		productTypes = VirtusizeAPIService.getProductTypesAsync().success
 		if productTypes == nil {
 			Virtusize.inPageError = (true, externalProductId)
-			return
+            return
 		}
 
 		i18nLocalization = VirtusizeAPIService.getI18nTextsAsync().success
 		if i18nLocalization == nil {
 			Virtusize.inPageError = (true, externalProductId)
-			return
+            return
 		}
 
-		onSuccess(serverStoreProduct!)
+        completion(storeProduct)
 	}
 
 	/// Fetches data for InPage recommendation
@@ -163,9 +163,12 @@ internal class VirtusizeRepository: NSObject {
 		shouldUpdateUserProducts: Bool = true,
 		shouldUpdateBodyProfile: Bool = true
 	) {
-		var storeProduct = storeProduct ?? lastProductOnVirtusizeWebView
-		if let productId = storeProduct?.id,
-		   let product = serverStoreProductSet.filter({ product in
+        guard var storeProduct = storeProduct ?? lastProductOnVirtusizeWebView else {
+            return
+        }
+
+        let productId = storeProduct.id
+		if let product = serverStoreProductSet.filter({ product in
 			product.id == productId
 		   }).first {
 			storeProduct = product
@@ -176,7 +179,7 @@ internal class VirtusizeRepository: NSObject {
 			if userProductsResponse.isSuccessful {
 				userProducts = userProductsResponse.success
 			} else if userProductsResponse.errorCode != 404 {
-				Virtusize.inPageError = (true, storeProduct!.externalId)
+				Virtusize.inPageError = (true, storeProduct.externalId)
 				return
 			}
 		}
@@ -186,7 +189,7 @@ internal class VirtusizeRepository: NSObject {
 			if userBodyProfileResponse.isSuccessful {
 				userBodyProfile = userBodyProfileResponse.success
 			} else if userBodyProfileResponse.errorCode != 404 {
-				Virtusize.inPageError = (true, storeProduct!.externalId)
+				Virtusize.inPageError = (true, storeProduct.externalId)
 				return
 			}
  		}
@@ -194,7 +197,7 @@ internal class VirtusizeRepository: NSObject {
 		if let userBodyProfile = userBodyProfile {
 			bodyProfileRecommendedSizes = VirtusizeAPIService.getBodyProfileRecommendedSizesAsync(
 				productTypes: productTypes!,
-				storeProduct: storeProduct!,
+				storeProduct: storeProduct,
 				userBodyProfile: userBodyProfile
 			).success
 		}
@@ -204,7 +207,7 @@ internal class VirtusizeRepository: NSObject {
 			userProducts.filter({ product in return product.id == selectedUserProductId }) : userProducts
 		sizeComparisonRecommendedSize = FindBestFitHelper.findBestFitProductSize(
 			userProducts: userProducts,
-			storeProduct: storeProduct!,
+			storeProduct: storeProduct,
 			productTypes: productTypes!
 		)
 	}
@@ -233,6 +236,7 @@ internal class VirtusizeRepository: NSObject {
 		if let sessionResponse = userSessionInfoResponse.string {
 			updateUserSessionResponse = sessionResponse
 		}
+
 		userSessionResponse = updateUserSessionResponse
 	}
 

--- a/Virtusize/Sources/VirtusizeRepository.swift
+++ b/Virtusize/Sources/VirtusizeRepository.swift
@@ -246,12 +246,10 @@ internal class VirtusizeRepository: NSObject {
 	///   - bid: a browser identifier
 	///   - auth: the auth token for the session API
 	internal func updateUserAuthData(bid: String?, auth: String?) {
-		if let bid = bid {
         if let bid = bid, bid != UserDefaultsHelper.current.undefinedValue {
 			UserDefaultsHelper.current.identifier = bid
 		}
-		if let auth = auth,
-		   !auth.isEmpty {
+		if let auth = auth, !auth.isEmpty {
 			UserDefaultsHelper.current.authToken = auth
 		}
 	}

--- a/Virtusize/Sources/VirtusizeRepository.swift
+++ b/Virtusize/Sources/VirtusizeRepository.swift
@@ -246,7 +246,7 @@ internal class VirtusizeRepository: NSObject {
 	///   - bid: a browser identifier
 	///   - auth: the auth token for the session API
 	internal func updateUserAuthData(bid: String?, auth: String?) {
-        if let bid = bid, bid != "undefined" {
+        if let bid = bid, bid != UserDefaultsHelper.current.undefinedValue {
 			UserDefaultsHelper.current.identifier = bid
 		}
 		if let auth = auth, !auth.isEmpty {

--- a/Virtusize/Sources/VirtusizeRepository.swift
+++ b/Virtusize/Sources/VirtusizeRepository.swift
@@ -246,7 +246,7 @@ internal class VirtusizeRepository: NSObject {
 	///   - bid: a browser identifier
 	///   - auth: the auth token for the session API
 	internal func updateUserAuthData(bid: String?, auth: String?) {
-        if let bid = bid, bid != UserDefaultsHelper.undefinedValue {
+        if let bid = bid, bid != "undefined" {
 			UserDefaultsHelper.current.identifier = bid
 		}
 		if let auth = auth, !auth.isEmpty {

--- a/Virtusize/Tests/APIEndpointsTests.swift
+++ b/Virtusize/Tests/APIEndpointsTests.swift
@@ -72,7 +72,7 @@ class APIEndpointsTests: XCTestCase {
 
         XCTAssertNil(endpoint.components.queryItems)
     }
-    
+
     func testLatestAoyamaVersionEndpoint_returnExpectedComponents() {
         let endpoint = APIEndpoints.latestAoyamaVersion
 

--- a/VirtusizeCore/Sources/Workers/UserDefaultsHelper.swift
+++ b/VirtusizeCore/Sources/Workers/UserDefaultsHelper.swift
@@ -30,6 +30,7 @@ final public class UserDefaultsHelper {
 	let authKey = "VIRTUSIZE_AUTH"
 	let tokenKey = "VIRTUSIZE_TOKEN"
 	let bidKey = "BID"
+    public let undefinedValue = "undefined"
 
 	/// A static instance of `UserDefaultsHelper` used inside the SDK
 	public static let current = UserDefaultsHelper()
@@ -72,7 +73,7 @@ final public class UserDefaultsHelper {
 	/// The browser identifier as String
 	public var identifier: String {
 		get {
-            if let token = defaults.value(forKey: bidKey) as? String, token != "undefined" {
+            if let token = defaults.value(forKey: bidKey) as? String, token != undefinedValue {
 				return token
 			} else {
 				let token = generateIdentifier()

--- a/VirtusizeCore/Sources/Workers/UserDefaultsHelper.swift
+++ b/VirtusizeCore/Sources/Workers/UserDefaultsHelper.swift
@@ -30,7 +30,7 @@ final public class UserDefaultsHelper {
 	let authKey = "VIRTUSIZE_AUTH"
 	let tokenKey = "VIRTUSIZE_TOKEN"
 	let bidKey = "BID"
-    public let undefinedValue = "undefined"
+    public static let undefinedValue = "undefined"
 
 	/// A static instance of `UserDefaultsHelper` used inside the SDK
 	public static let current = UserDefaultsHelper()

--- a/VirtusizeCore/Sources/Workers/UserDefaultsHelper.swift
+++ b/VirtusizeCore/Sources/Workers/UserDefaultsHelper.swift
@@ -30,6 +30,7 @@ final public class UserDefaultsHelper {
 	let authKey = "VIRTUSIZE_AUTH"
 	let tokenKey = "VIRTUSIZE_TOKEN"
 	let bidKey = "BID"
+    public let undefinedValue = "undefined"
 
 	/// A static instance of `UserDefaultsHelper` used inside the SDK
 	public static let current = UserDefaultsHelper()
@@ -72,7 +73,7 @@ final public class UserDefaultsHelper {
 	/// The browser identifier as String
 	public var identifier: String {
 		get {
-			if let token = defaults.value(forKey: bidKey) as? String {
+			if let token = defaults.value(forKey: bidKey) as? String, token != undefinedValue {
 				return token
 			} else {
 				let token = generateIdentifier()

--- a/VirtusizeCore/Sources/Workers/UserDefaultsHelper.swift
+++ b/VirtusizeCore/Sources/Workers/UserDefaultsHelper.swift
@@ -30,7 +30,6 @@ final public class UserDefaultsHelper {
 	let authKey = "VIRTUSIZE_AUTH"
 	let tokenKey = "VIRTUSIZE_TOKEN"
 	let bidKey = "BID"
-    public static let undefinedValue = "undefined"
 
 	/// A static instance of `UserDefaultsHelper` used inside the SDK
 	public static let current = UserDefaultsHelper()
@@ -73,7 +72,7 @@ final public class UserDefaultsHelper {
 	/// The browser identifier as String
 	public var identifier: String {
 		get {
-			if let token = defaults.value(forKey: bidKey) as? String, token != undefinedValue {
+            if let token = defaults.value(forKey: bidKey) as? String, token != "undefined" {
 				return token
 			} else {
 				let token = generateIdentifier()


### PR DESCRIPTION
## 🔗 Related Links

- [x] [ClickUp](https://app.clickup.com/t/3702259/NSDK-220)
- [ ] [Figma](https://www.figma.com/file/XXXXXX)

## ⬅️ As Is

If we click on the native UI component like VirtusizeButton, VirtusizeInPageStandard, and VirtusizePageMini when the user-session request is not finished yet, the web view page will be in the loading state forever because the data sent via vsParamsFromSDK lacks session data.

## ➡️ To Be

We need to make sure we get the user session data from the server before opening the web view.
When notifying productDataCheck (finished) to the UI components, the UI component becomes unhidden, so making sure to get the user session data before broadcasting the notification will solve the issue, which is the fastest way due to the limited development time.

## ☑️ Checklist

- [x] Useless comments and/or `print` etc are **removed**
- [ ] Unit test are **covered**
- [ ] Code has been **deployed and tested** on STG
- [ ] ClickUp ticket status has been **updated** to `production`
- [x] Update CHANGELOG.md with the new changes
