### PR TITLE
[NSDK-228] Hotfix 2.6.1 – Fix for Duplicate VirtusizeCore Bundles

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,9 @@ Use list notation, and following prefixes:
 
 ## NEXT RELEASE for Version 2.x.x
 
+### 2.6.1
+- Fix: Fix for Duplicate VirtusizeCore Bundles
+
 ### 2.6.0
 - Refactor: Update the Virtusize web view URL to the following format: https://static.api.virtusize.jp/a/aoyama/\(version)/sdk-webview.html
 - Feature: Add the client sepecifc Virtusize web view URL. The format is as follows: https://static.api.virtusize.jp/a/aoyama/testing/privacy-policy-phase2-vue/sdk-webview.html

--- a/Virtusize.podspec
+++ b/Virtusize.podspec
@@ -20,7 +20,7 @@ Pod::Spec.new do |s|
   s.pod_target_xcconfig = { 'BUILD_LIBRARY_FOR_DISTRIBUTION' => 'YES' }
   s.subspec 'VirtusizeCore' do |core|
       core.source_files = ['VirtusizeCore/Sources/*.{swift, h}', 'VirtusizeCore/Sources/**/*.swift']
-      core.resource_bundle = { 'VirtusizeCore' => ['VirtusizeCore/Sources/Resources/**/*.lproj', "VirtusizeCore/Sources/Resources/PrivacyInfo.xcprivacy"] }
+      core.resource_bundle = { 'Virtusize_VirtusizeCore' => ['VirtusizeCore/Sources/Resources/**/*.lproj', "VirtusizeCore/Sources/Resources/PrivacyInfo.xcprivacy"] }
   end
   s.dependency "VirtusizeAuth", "<= 1.1.5"
 end

--- a/Virtusize/Sources/Internal/Utils/Image+Extensions.swift
+++ b/Virtusize/Sources/Internal/Utils/Image+Extensions.swift
@@ -31,9 +31,13 @@ internal extension UIImage {
 	/// Creates a `UIImage` object in the Virtusize framework bundle.
 	///
 	/// - Parameter name: The image name.
-	convenience init?(bundleNamed name: String) {
-		self.init(named: name, in: VirtusizeBundleLoader.resourceBundle, compatibleWith: nil)
-	}
+    convenience init?(bundleNamed name: String) {
+        self.init(
+            named: name,
+            in: VirtusizeBundleLoader.resourceBundle(bundleName: VirtusizeConfiguration.resourceBundleName),
+            compatibleWith: nil
+        )
+    }
 
 	/// Adds the padding to a `UIImage`
 	///

--- a/Virtusize/Sources/Internal/Utils/Localization.swift
+++ b/Virtusize/Sources/Internal/Utils/Localization.swift
@@ -38,6 +38,7 @@ internal class Localization {
 	/// - Returns: A localized string based on the device's default language
 	func localize(_ key: String, language: VirtusizeLanguage? = nil) -> String {
 		return VirtusizeCoreBundleLoader.localizationBundle(
+            bundleName: VirtusizeConfiguration.resourceBundleName,
 			language: language?.rawValue ?? Virtusize.params?.language.rawValue
 		).localizedString(
 			forKey: key, value: nil, table: "VirtusizeLocalizable"

--- a/Virtusize/Sources/VirtusizeConfiguration.swift
+++ b/Virtusize/Sources/VirtusizeConfiguration.swift
@@ -27,4 +27,5 @@ import Foundation
 struct VirtusizeConfiguration {
 	static let SDKVersion = "2.6.0"
     static let defaultAoyamaVersion = "3.3.2"
+    static let resourceBundleName = "Virtusize_VirtusizeCore"
 }

--- a/Virtusize/Sources/VirtusizeConfiguration.swift
+++ b/Virtusize/Sources/VirtusizeConfiguration.swift
@@ -26,5 +26,5 @@ import Foundation
 
 struct VirtusizeConfiguration {
 	static let SDKVersion = "2.6.0"
-    static let defaultAoyamaVersion = "3.3.1"
+    static let defaultAoyamaVersion = "3.3.2"
 }

--- a/VirtusizeCore/Sources/Utils/BundleLoaderProtocal.swift
+++ b/VirtusizeCore/Sources/Utils/BundleLoaderProtocal.swift
@@ -27,7 +27,6 @@ import Foundation
 
 public protocol BundleLoaderProtocol {
 	static var bundleClass: AnyClass { get }
-	static var bundleName: String { get }
 	#if SWIFT_PACKAGE
 	static var spmResourceBundle: Bundle { get }
 	#endif
@@ -35,7 +34,8 @@ public protocol BundleLoaderProtocol {
 
 public extension BundleLoaderProtocol {
 	/// The bundle is used for resources like images
-	static var resourceBundle: Bundle {
+    /// - Parameter bundleName: The resource bundle name
+    static func resourceBundle(bundleName: String) -> Bundle {
 		var bundle: Bundle?
 		// Swift Package Manager bundle
 		#if SWIFT_PACKAGE
@@ -68,9 +68,12 @@ public extension BundleLoaderProtocol {
 	}
 
 	/// Gets the bundle that is used for localization
-	/// - Parameter language: `VirtusizeLanguage`
-	static func localizationBundle(language: String? = nil) -> Bundle {
-		var bundle = resourceBundle
+	/// - Parameter
+    /// - Parameters:
+    ///   - bundleName: The resource bundle name
+    ///   - language: `VirtusizeLanguage`
+    static func localizationBundle(bundleName: String, language: String? = nil) -> Bundle {
+        var bundle = resourceBundle(bundleName: bundleName)
 		if let localizableBundlePath = bundle.path(
 			forResource: language,
 			ofType: "lproj"

--- a/VirtusizeCore/Sources/Utils/VirtusizeCoreBundleLoader.swift
+++ b/VirtusizeCore/Sources/Utils/VirtusizeCoreBundleLoader.swift
@@ -27,9 +27,8 @@ import Foundation
 
 /// The class is to access different types of bundles for the SDK
 open class VirtusizeCoreBundleLoader: BundleLoaderProtocol {
-	public static let bundleClass: AnyClass = VirtusizeCoreBundleLoader.self
-	public static let bundleName = "Virtusize_VirtusizeCore"
-	#if SWIFT_PACKAGE
-	public static let spmResourceBundle  = Bundle.module
-	#endif
+    public static let bundleClass: AnyClass = VirtusizeCoreBundleLoader.self
+    #if SWIFT_PACKAGE
+    public static let spmResourceBundle  = Bundle.module
+    #endif
 }

--- a/VirtusizeCore/Sources/Utils/VirtusizeCoreBundleLoader.swift
+++ b/VirtusizeCore/Sources/Utils/VirtusizeCoreBundleLoader.swift
@@ -28,7 +28,7 @@ import Foundation
 /// The class is to access different types of bundles for the SDK
 open class VirtusizeCoreBundleLoader: BundleLoaderProtocol {
 	public static let bundleClass: AnyClass = VirtusizeCoreBundleLoader.self
-	public static let bundleName = "VirtusizeCore"
+	public static let bundleName = "Virtusize_VirtusizeCore"
 	#if SWIFT_PACKAGE
 	public static let spmResourceBundle  = Bundle.module
 	#endif


### PR DESCRIPTION
## 🔗 Related Links

- [x] [ClickUp](https://app.clickup.com/t/3702259/NSDK-228)

## ⬅️ As Is

<img width="1113" alt="Screenshot 2024-10-19 at 23 39 42" src="https://github.com/user-attachments/assets/e246fc1f-0666-4db7-b3fd-aa6678af5f5b">

## ➡️ To Be

- [x] Renamed the bundle name to avoid a duplicate bundle name

## ☑️ Checklist

- [x] Useless comments and/or `print` etc are **removed**
- [ ] Unit test are **covered**
- [ ] Code has been **deployed and tested** on STG
- [ ] ClickUp ticket status has been **updated** to `production`
- [x] Update CHANGELOG.md with the new changes
