### PR TITLE
[NSDK-240][NSDK-238][NSDK-241][NSDK-242] Fix InPage Issues

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,12 @@ Use list notation, and following prefixes:
 
 ## NEXT RELEASE for Version 2.x.x
 
+### Next release
+- Fix: Inpage doesn’t recommend anything after coming back to PDP from Comparison screen
+- Fix: Inpage text for on-boarding user has 2 patterns at random
+- Fix: Inpage shows different size from that VS widget shows
+- Fix: Body data tuning is not saved once closing the widget
+
 ### 2.6.4
 - Fix: Fix the product image resolution
 

--- a/Example/Sources/ViewController.swift
+++ b/Example/Sources/ViewController.swift
@@ -28,186 +28,186 @@ import Virtusize
 
 class ViewController: UIViewController {
 
-	@IBOutlet weak var checkTheFitButton: VirtusizeButton!
-	@IBOutlet weak var inPageMini: VirtusizeInPageMini!
+    @IBOutlet weak var checkTheFitButton: VirtusizeButton!
+    @IBOutlet weak var inPageMini: VirtusizeInPageMini!
 
-	// swiftlint:disable function_body_length
-	override func viewDidLoad() {
-		super.viewDidLoad()
+    // swiftlint:disable function_body_length
+    override func viewDidLoad() {
+        super.viewDidLoad()
 
-		setNavigationBarStyle()
+        setNavigationBarStyle()
 
-		// NotificationCenter listener for debugging the initial product data check
-		// - `Virtusize.productDataCheckDidFail`, the `UserInfo` will contain a message
-		// with the cause of the failure
-		// - `Virtusize.productDataCheckDidSucceed`
-		NotificationCenter.default.addObserver(
-			self,
-			selector: #selector(productDataCheckDidFail(_:)),
-			name: Virtusize.productDataCheckDidFail,
-			object: Virtusize.self
-		)
-		NotificationCenter.default.addObserver(
-			self,
-			selector: #selector(productDataCheckDidSucceed(_:)),
-			name: Virtusize.productDataCheckDidSucceed,
-			object: Virtusize.self
-		)
+        // NotificationCenter listener for debugging the initial product data check
+        // - `Virtusize.productCheckDidFail`, the `UserInfo` will contain a message
+        // with the cause of the failure
+        // - `Virtusize.productCheckDidSucceed`
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(productCheckDidFail(_:)),
+            name: Virtusize.productCheckDidFail,
+            object: Virtusize.self
+        )
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(productCheckDidSucceed(_:)),
+            name: Virtusize.productCheckDidSucceed,
+            object: Virtusize.self
+        )
 
-		/// Set up the product information
-		let product1 = VirtusizeProduct(
-			externalId: "vs_dress",
-			imageURL: URL(string: "http://www.example.com/image.jpg")
-		)
-		/// Loads the product in order to populate the Virtusize views associated with `product1`
-		Virtusize.load(product: product1)
+        /// Set up the product information
+        let product1 = VirtusizeProduct(
+            externalId: "vs_dress",
+            imageURL: URL(string: "http://www.example.com/image.jpg")
+        )
+        /// Loads the product in order to populate the Virtusize views associated with `product1`
+        Virtusize.load(product: product1)
 
-		/// Set up the product information
-		let product2 = VirtusizeProduct(
-			externalId: "vs_pants",
-			imageURL: URL(string: "http://www.example.com/image.jpg")
-		)
-		/// Loads the product in order to populate the Virtusize views associated with `product2`
-		Virtusize.load(product: product2)
+        /// Set up the product information
+        let product2 = VirtusizeProduct(
+            externalId: "vs_pants",
+            imageURL: URL(string: "http://www.example.com/image.jpg")
+        )
+        /// Loads the product in order to populate the Virtusize views associated with `product2`
+        Virtusize.load(product: product2)
 
-		// Optional: Set up WKProcessPool to allow cookie sharing.
-		Virtusize.processPool = WKProcessPool()
+        // Optional: Set up WKProcessPool to allow cookie sharing.
+        Virtusize.processPool = WKProcessPool()
 
-		// MARK: VirtusizeButton
-		// 1. Set up checkTheFitButton that is added in Interface Builder
-		Virtusize.setVirtusizeView(self, checkTheFitButton, product: product1)
-		// You can set up the Virtusize button style
-		checkTheFitButton.style = .TEAL
+        // MARK: VirtusizeButton
+        // 1. Set up checkTheFitButton that is added in Interface Builder
+        Virtusize.setVirtusizeView(self, checkTheFitButton, product: product1)
+        // You can set up the Virtusize button style
+        checkTheFitButton.style = .TEAL
 
-		/// you can use `VirtusizeAssets` to access Virtusize SDK assets, including images and colors
-		// checkTheFitButton.setImage(VirtusizeAssets.icon, for: .normal)
+        /// you can use `VirtusizeAssets` to access Virtusize SDK assets, including images and colors
+        // checkTheFitButton.setImage(VirtusizeAssets.icon, for: .normal)
 
-		// 2. Add the VirtusizeButton programmatically
-		let checkTheFitButton2 = VirtusizeButton()
-		view.addSubview(checkTheFitButton2)
-		Virtusize.setVirtusizeView(self, checkTheFitButton2, product: product2)
-		checkTheFitButton2.style = .BLACK
-		// Set up constraints if needed
-		checkTheFitButton2.translatesAutoresizingMaskIntoConstraints = false
-		checkTheFitButton2.centerXAnchor.constraint(equalTo: view.centerXAnchor).isActive = true
-		checkTheFitButton2.bottomAnchor.constraint(equalTo: checkTheFitButton.topAnchor, constant: -16).isActive = true
+        // 2. Add the VirtusizeButton programmatically
+        let checkTheFitButton2 = VirtusizeButton()
+        view.addSubview(checkTheFitButton2)
+        Virtusize.setVirtusizeView(self, checkTheFitButton2, product: product2)
+        checkTheFitButton2.style = .BLACK
+        // Set up constraints if needed
+        checkTheFitButton2.translatesAutoresizingMaskIntoConstraints = false
+        checkTheFitButton2.centerXAnchor.constraint(equalTo: view.centerXAnchor).isActive = true
+        checkTheFitButton2.bottomAnchor.constraint(equalTo: checkTheFitButton.topAnchor, constant: -16).isActive = true
 
-		// MARK: VirtusizeInPageMini
-		// 1. Set up inPageMini that is added in Interface Builder
-		Virtusize.setVirtusizeView(self, inPageMini, product: product1)
-		// You can set the Virtusize InPage Mini style
-		inPageMini.style = .BLACK
+        // MARK: VirtusizeInPageMini
+        // 1. Set up inPageMini that is added in Interface Builder
+        Virtusize.setVirtusizeView(self, inPageMini, product: product1)
+        // You can set the Virtusize InPage Mini style
+        inPageMini.style = .BLACK
 
-		// 2. If you add the InPageMini view programmatically
-		let inPageMini2 = VirtusizeInPageMini()
-		view.addSubview(inPageMini2)
-		Virtusize.setVirtusizeView(self, inPageMini2, product: product2)
-		inPageMini2.inPageMiniBackgroundColor = #colorLiteral(red: 0.262745098, green: 0.5960784314, blue: 0.9882352941, alpha: 1)
-		// You can set the horizontal margins by using `setHorizontalMargin`
-		inPageMini2.setHorizontalMargin(view: view, margin: 16)
-		// You can set the font sizes for the InPage Mini texts
-		inPageMini2.messageFontSize = 12
-		inPageMini2.buttonFontSize = 10
-		// Set up constraints if needed
-		inPageMini2.translatesAutoresizingMaskIntoConstraints = false
-		inPageMini2.topAnchor.constraint(equalTo: inPageMini.bottomAnchor, constant: 16).isActive = true
+        // 2. If you add the InPageMini view programmatically
+        let inPageMini2 = VirtusizeInPageMini()
+        view.addSubview(inPageMini2)
+        Virtusize.setVirtusizeView(self, inPageMini2, product: product2)
+        inPageMini2.inPageMiniBackgroundColor = #colorLiteral(red: 0.262745098, green: 0.5960784314, blue: 0.9882352941, alpha: 1)
+        // You can set the horizontal margins by using `setHorizontalMargin`
+        inPageMini2.setHorizontalMargin(view: view, margin: 16)
+        // You can set the font sizes for the InPage Mini texts
+        inPageMini2.messageFontSize = 12
+        inPageMini2.buttonFontSize = 10
+        // Set up constraints if needed
+        inPageMini2.translatesAutoresizingMaskIntoConstraints = false
+        inPageMini2.topAnchor.constraint(equalTo: inPageMini.bottomAnchor, constant: 16).isActive = true
 
-		// MARK: VirtusizeInPageStandard
-		// If you add the InPageMini view programmatically
-		let inPageStandard = VirtusizeInPageStandard()
-		view.addSubview(inPageStandard)
-		Virtusize.setVirtusizeView(self, inPageStandard, product: product1)
-		// You can set the horizontal margins by using `setHorizontalMargin`
-		inPageStandard.setHorizontalMargin(view: view, margin: 16)
-		// You can set the Virtusize InPage Standard style
-		inPageStandard.style = .BLACK
-		// You can set the background color of the size check button
-		inPageStandard.inPageStandardButtonBackgroundColor = #colorLiteral(red: 0.09803921569, green: 0.09803921569, blue: 0.09803921569, alpha: 1)
-		// You can set the font sizes for the InPage texts
-		inPageStandard.buttonFontSize = 12
-		inPageStandard.messageFontSize = 12
-		// Set up constraints if needed
-		inPageStandard.translatesAutoresizingMaskIntoConstraints = false
-		inPageStandard.centerXAnchor.constraint(equalTo: view.centerXAnchor).isActive = true
-		inPageStandard.topAnchor.constraint(equalTo: inPageMini2.bottomAnchor, constant: 16).isActive = true
+        // MARK: VirtusizeInPageStandard
+        // If you add the InPageMini view programmatically
+        let inPageStandard = VirtusizeInPageStandard()
+        view.addSubview(inPageStandard)
+        Virtusize.setVirtusizeView(self, inPageStandard, product: product1)
+        // You can set the horizontal margins by using `setHorizontalMargin`
+        inPageStandard.setHorizontalMargin(view: view, margin: 16)
+        // You can set the Virtusize InPage Standard style
+        inPageStandard.style = .BLACK
+        // You can set the background color of the size check button
+        inPageStandard.inPageStandardButtonBackgroundColor = #colorLiteral(red: 0.09803921569, green: 0.09803921569, blue: 0.09803921569, alpha: 1)
+        // You can set the font sizes for the InPage texts
+        inPageStandard.buttonFontSize = 12
+        inPageStandard.messageFontSize = 12
+        // Set up constraints if needed
+        inPageStandard.translatesAutoresizingMaskIntoConstraints = false
+        inPageStandard.centerXAnchor.constraint(equalTo: view.centerXAnchor).isActive = true
+        inPageStandard.topAnchor.constraint(equalTo: inPageMini2.bottomAnchor, constant: 16).isActive = true
 
-		// MARK: The Order API
-		sendOrderSample()
-	}
+        // MARK: The Order API
+        sendOrderSample()
+    }
 
-	/// Demonstrates how to send an order to the Virtusize server
-	///
-	/// - Note:
-	/// The properties `sizeAlias`, `variantId`, `color`, `gender` and `url`
-	/// for `VirtusizeOrderItem` are optional
-	///
-	/// If `quantity` is not provided, it will be set to 1 automatically
-	///
-	private func sendOrderSample() {
-		var virtusizeOrder = VirtusizeOrder(externalOrderId: "4000111032")
-		let item = VirtusizeOrderItem(
-			externalProductId: "A00001",
-			size: "L",
-			sizeAlias: "Large",
-			variantId: "A00001_SIZEL_RED",
-			imageUrl: "http://images.example.com/products/A00001/red/image1xl.jpg",
-			color: "Red",
-			gender: "W",
-			unitPrice: 5100.00,
-			currency: "JPY",
-			quantity: 1,
-			url: "http://example.com/products/A00001"
-		)
-		virtusizeOrder.items = [item]
+    /// Demonstrates how to send an order to the Virtusize server
+    ///
+    /// - Note:
+    /// The properties `sizeAlias`, `variantId`, `color`, `gender` and `url`
+    /// for `VirtusizeOrderItem` are optional
+    ///
+    /// If `quantity` is not provided, it will be set to 1 automatically
+    ///
+    private func sendOrderSample() {
+        var virtusizeOrder = VirtusizeOrder(externalOrderId: "4000111032")
+        let item = VirtusizeOrderItem(
+            externalProductId: "A00001",
+            size: "L",
+            sizeAlias: "Large",
+            variantId: "A00001_SIZEL_RED",
+            imageUrl: "http://images.example.com/products/A00001/red/image1xl.jpg",
+            color: "Red",
+            gender: "W",
+            unitPrice: 5100.00,
+            currency: "JPY",
+            quantity: 1,
+            url: "http://example.com/products/A00001"
+        )
+        virtusizeOrder.items = [item]
 
-		Virtusize.sendOrder(
-			virtusizeOrder,
-			// This success callback is optional and gets called when the app successfully sends the order
-			onSuccess: {
-				print("Successfully sent the order")
-			},
-			// This error callback is optional and gets called when an error occurs
-			// when the app is sending the order
-			onError: { error in
-				print("Failed to send the order, error: \(error.debugDescription)")
-			})
-	}
+        Virtusize.sendOrder(
+            virtusizeOrder,
+            // This success callback is optional and gets called when the app successfully sends the order
+            onSuccess: {
+                print("Successfully sent the order")
+            },
+            // This error callback is optional and gets called when an error occurs
+            // when the app is sending the order
+            onError: { error in
+                print("Failed to send the order, error: \(error.debugDescription)")
+            })
+    }
 
-	// You should use those to debug during development
-	@objc func productDataCheckDidFail(_ notification: Notification) {
-		print(notification)
-	}
-	@objc func productDataCheckDidSucceed(_ notification: Notification) {
-		print(notification)
-	}
+    // You should use those to debug during development
+    @objc func productCheckDidFail(_ notification: Notification) {
+        print(notification)
+    }
+    @objc func productCheckDidSucceed(_ notification: Notification) {
+        print(notification)
+    }
 
-	private func setNavigationBarStyle() {
-		navigationItem.title = "Virtusize Example App"
-		navigationController?.navigationBar.tintColor = UIColor.white
-		let textAttributes = [
-			NSAttributedString.Key.foregroundColor: UIColor.white
-		]
-		navigationController?.navigationBar.titleTextAttributes = textAttributes
-		navigationController?.navigationBar.barStyle = UIBarStyle.blackTranslucent
-		navigationController?.navigationBar.barTintColor = UIColor.vsTealColor
-	}
+    private func setNavigationBarStyle() {
+        navigationItem.title = "Virtusize Example App"
+        navigationController?.navigationBar.tintColor = UIColor.white
+        let textAttributes = [
+            NSAttributedString.Key.foregroundColor: UIColor.white
+        ]
+        navigationController?.navigationBar.titleTextAttributes = textAttributes
+        navigationController?.navigationBar.barStyle = UIBarStyle.blackTranslucent
+        navigationController?.navigationBar.barTintColor = UIColor.vsTealColor
+    }
 }
 
 extension ViewController: VirtusizeMessageHandler {
-	func virtusizeController(_ controller: VirtusizeWebViewController?, didReceiveEvent event: VirtusizeEvent) {
-		print(event)
-		// swiftlint:disable switch_case_alignment
-		switch event.name {
-			case "user-opened-widget":
-				return
-			case "user-opened-panel-compare":
-				return
-			default:
-				return
-		}
-	}
+    func virtusizeController(_ controller: VirtusizeWebViewController?, didReceiveEvent event: VirtusizeEvent) {
+        print(event)
+        // swiftlint:disable switch_case_alignment
+        switch event.name {
+            case "user-opened-widget":
+                return
+            case "user-opened-panel-compare":
+                return
+            default:
+                return
+        }
+    }
 
-	func virtusizeController(_ controller: VirtusizeWebViewController?, didReceiveError error: VirtusizeError) {
-		print(error)
-	}
+    func virtusizeController(_ controller: VirtusizeWebViewController?, didReceiveError error: VirtusizeError) {
+        print(error)
+    }
 }

--- a/README-JP.md
+++ b/README-JP.md
@@ -285,8 +285,8 @@ Virtusize.processPool = WKProcessPool()
 
 そのAPIコールをデバッグするために、`NotificationCenter`をサブスクライブし、2つの`Notification.Name`エイリアスを観ることができます。
 
-- `Virtusize.productDataCheckDidFai`lは、失敗の原因を持つメッセージを含む`UserInfo`を受け取ります。
-- `Virtusize.productDataCheckDidSucceed`は、呼び出しが成功した場合に送信されます。
+- `Virtusize.productCheckDidFai`lは、失敗の原因を持つメッセージを含む`UserInfo`を受け取ります。
+- `Virtusize.productCheckDidSucceed`は、呼び出しが成功した場合に送信されます。
 
 チェックに失敗した場合は、ボタンが非表示になります。
 

--- a/README.md
+++ b/README.md
@@ -264,8 +264,8 @@ When the button is initialized with an `exernalId` , the SDK calls our API to ch
 
 In order to debug that API call, you can subscribe to the `NotificationCenter` and observe two `Notification.Name` aliases:
 
-- `Virtusize.productDataCheckDidFail`, which receives the `UserInfo` containing a message with the cause of the failure.
-- `Virtusize.productDataCheckDidSucceed` that will be sent if the call is succesfull.
+- `Virtusize.productCheckDidFail`, which receives the `UserInfo` containing a message with the cause of the failure.
+- `Virtusize.productCheckDidSucceed` that will be sent if the call is succesfull.
 
 If the check fails, the button will be hidden.
 

--- a/Virtusize/Sources/Flutter/VirtusizeFlutterReposiory.swift
+++ b/Virtusize/Sources/Flutter/VirtusizeFlutterReposiory.swift
@@ -31,7 +31,7 @@ public class VirtusizeFlutterRepository: NSObject {
 		return instance
 	}()
 
-	public func getProductDataCheck(
+	public func getProductCheckData(
 		messageHandler: VirtusizeMessageHandler?,
 		product: VirtusizeProduct
 	) -> (VirtusizeProduct?, String?) {

--- a/Virtusize/Sources/Internal/API/APIEndpoints.swift
+++ b/Virtusize/Sources/Internal/API/APIEndpoints.swift
@@ -26,7 +26,7 @@ import Foundation
 
 /// This enum represents all available Virtusize endpoints
 internal enum APIEndpoints {
-	case productDataCheck(externalId: String)
+	case productCheck(externalId: String)
 	case productMetaDataHints
 	case events
     case latestAoyamaVersion
@@ -47,7 +47,7 @@ internal enum APIEndpoints {
     // MARK: - Properties
     var hostname: String {
         switch self {
-            case .productDataCheck:
+            case .productCheck:
                 return Virtusize.environment.servicesUrl()
             case  .getSize:
                 return Virtusize.environment.getSizeUrl()
@@ -67,7 +67,7 @@ internal enum APIEndpoints {
         components.scheme = "https"
         components.host = hostname
         switch self {
-            case .productDataCheck(let externalId):
+            case .productCheck(let externalId):
                 let envPathForServicesAPI = Virtusize.environment.isProdEnv ? "" : "/stg"
                 components.path = "\(envPathForServicesAPI)/product/check"
                 components.queryItems = dataCheckQueryItems(externalId: externalId)
@@ -132,7 +132,7 @@ internal enum APIEndpoints {
 
 	// MARK: - Helper methods
 
-	/// Builds query parameters for the API endpoint `productDataCheck`
+	/// Builds query parameters for the API endpoint `productCheck`
 	///
 	/// - Parameter externalId: A string to represent the id that will be used to reference
 	///  this product in Virtusize API

--- a/Virtusize/Sources/Internal/API/APIEvent.swift
+++ b/Virtusize/Sources/Internal/API/APIEvent.swift
@@ -56,11 +56,11 @@ internal struct APIEvent {
 		]
 	}
 
-	/// Adds the response from Virtusize API for the `productDataCheck` request to payload
+	/// Adds the response from Virtusize API for the `productCheck` request to payload
 	///
-	/// - Parameter json: The product data from the response of the `productDataCheck` request
-	mutating func align(withContext productDataCheck: JSONObject?) {
-		guard let root = productDataCheck,
+	/// - Parameter json: The product data from the response of the `productCheck` request
+	mutating func align(withContext productCheckData: JSONObject?) {
+		guard let root = productCheckData,
 			  let data = root["data"] as? JSONObject else {
 			return
 		}

--- a/Virtusize/Sources/Internal/API/VirtusizeAPIRequest.swift
+++ b/Virtusize/Sources/Internal/API/VirtusizeAPIRequest.swift
@@ -31,7 +31,7 @@ extension APIRequest {
 	/// - Parameter product: `VirtusizeProduct` for which check needs to be performed
 	/// - Returns: A `URLRequest` for the `productCheck` request
 	internal static func productCheck(product: VirtusizeProduct) -> URLRequest {
-		let endpoint = APIEndpoints.productDataCheck(externalId: product.externalId)
+		let endpoint = APIEndpoints.productCheck(externalId: product.externalId)
 		return apiRequest(components: endpoint.components)
 	}
 
@@ -64,7 +64,7 @@ extension APIRequest {
 	///
 	/// - Parameters:
 	///   - virtusizeEvent: An event to be sent to the Virtusize server
-	///   - context: The product data from the response of the `productDataCheck` request
+	///   - context: The product data from the response of the `productCheck` request
 	/// - Returns: A `URLRequest` for the `sendEvent` request
 	internal static func sendEvent(
 		_ virtusizeEvent: VirtusizeEvent, withContext context: JSONObject?) -> URLRequest? {

--- a/Virtusize/Sources/Internal/API/VirtusizeAPIService.swift
+++ b/Virtusize/Sources/Internal/API/VirtusizeAPIService.swift
@@ -36,7 +36,7 @@ class VirtusizeAPIService: APIService {
 	internal static func productCheckAsync(product: VirtusizeProduct) -> APIResult<VirtusizeProduct> {
 		let request = APIRequest.productCheck(product: product)
 		let result = getAPIResultAsync(request: request, type: VirtusizeProduct.self)
-        currentStoreId = result.success?.productCheckData?.storeId
+        APICache.shared.currentStoreId = result.success?.productCheckData?.storeId
         return result
 	}
 

--- a/Virtusize/Sources/Internal/API/VirtusizeAPIService.swift
+++ b/Virtusize/Sources/Internal/API/VirtusizeAPIService.swift
@@ -27,7 +27,7 @@ import Foundation
 import VirtusizeCore
 
 /// This class is to handle API requests to the Virtusize server
-class VirtusizeAPIService: APIService {
+class VirtusizeAPIService: APIService {    
 	/// The API request for product check
 	///
 	/// - Parameters:
@@ -35,7 +35,9 @@ class VirtusizeAPIService: APIService {
 	/// - Returns: the product check data in the type of `VirtusizeProduct`
 	internal static func productCheckAsync(product: VirtusizeProduct) -> APIResult<VirtusizeProduct> {
 		let request = APIRequest.productCheck(product: product)
-		return getAPIResultAsync(request: request, type: VirtusizeProduct.self)
+		let result = getAPIResultAsync(request: request, type: VirtusizeProduct.self)
+        storeId = result.success?.productCheckData?.storeId
+        return result
 	}
 
 	/// The API request for sending image of VirtusizeProduct to the Virtusize server

--- a/Virtusize/Sources/Internal/API/VirtusizeAPIService.swift
+++ b/Virtusize/Sources/Internal/API/VirtusizeAPIService.swift
@@ -36,7 +36,7 @@ class VirtusizeAPIService: APIService {
 	internal static func productCheckAsync(product: VirtusizeProduct) -> APIResult<VirtusizeProduct> {
 		let request = APIRequest.productCheck(product: product)
 		let result = getAPIResultAsync(request: request, type: VirtusizeProduct.self)
-        storeId = result.success?.productCheckData?.storeId
+        currentStoreId = result.success?.productCheckData?.storeId
         return result
 	}
 

--- a/Virtusize/Sources/Internal/API/VirtusizeAPIService.swift
+++ b/Virtusize/Sources/Internal/API/VirtusizeAPIService.swift
@@ -27,7 +27,7 @@ import Foundation
 import VirtusizeCore
 
 /// This class is to handle API requests to the Virtusize server
-class VirtusizeAPIService: APIService {    
+class VirtusizeAPIService: APIService {
 	/// The API request for product check
 	///
 	/// - Parameters:

--- a/Virtusize/Sources/Internal/API/VirtusizeAPIService.swift
+++ b/Virtusize/Sources/Internal/API/VirtusizeAPIService.swift
@@ -67,7 +67,7 @@ class VirtusizeAPIService: APIService {
 	///
 	/// - Parameters:
 	///   - event: An event to be sent to the Virtusize server
-	///   - context: The product data from the response of the `productDataCheck` request
+	///   - context: The product data from the response of the `productCheck` request
 	///   - completionHandler: A callback to pass `JSONObject` back when an API request is successful
 	internal static func sendEvent(
 		_ event: VirtusizeEvent,

--- a/Virtusize/Sources/Internal/Models/VirtusizeGetSizeItemsParam.swift
+++ b/Virtusize/Sources/Internal/Models/VirtusizeGetSizeItemsParam.swift
@@ -1,17 +1,29 @@
 //
-//  VirtusizeGetSizeItemsParama.swift
-//  Virtusize
+//  Copyright (c) 2023 Virtusize KK
 //
-//  Created by admin on 13/12/23.
-//  Copyright © 2023 Virtusize AB. All rights reserved.
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
 //
 
 import Foundation
 struct VirtusizeGetSizeItemsParam: Codable {
-
     var additionalInfo: [String: VirtusizeAnyCodable] = [:]
     var itemSizesOrig: [String: [String: Int?]] = [:]
     var productType: String
     var extProductId: String
-
 }

--- a/Virtusize/Sources/Internal/Models/VirtusizeGetSizeParams.swift
+++ b/Virtusize/Sources/Internal/Models/VirtusizeGetSizeParams.swift
@@ -59,7 +59,7 @@ internal struct VirtusizeGetSizeParams: Codable {
             "sizes": VirtusizeAnyCodable(
                 storeProduct.storeProductMeta?.additionalInfo?.sizes ?? [:]
             ),
-            "model_info": VirtusizeAnyCodable(getModelInfoDict(storeProduct: storeProduct)),
+            "modelInfo": VirtusizeAnyCodable(getModelInfoDict(storeProduct: storeProduct)),
             "gender": VirtusizeAnyCodable(
                 userBodyProfile?.gender ?? nil
             )

--- a/Virtusize/Sources/Internal/Models/VirtusizeGetSizeParams.swift
+++ b/Virtusize/Sources/Internal/Models/VirtusizeGetSizeParams.swift
@@ -34,7 +34,7 @@ internal struct VirtusizeGetSizeParams: Codable {
     var userHeight: Int?
     /// The user's weight
     var userWeight: Float?
-
+    /// The user's items
     var items: [VirtusizeGetSizeItemsParam]
 
     /// Initializes the VirtusizeGetSizeParams structure
@@ -49,9 +49,6 @@ internal struct VirtusizeGetSizeParams: Codable {
         userBodyProfile: VirtusizeUserBodyProfile?
 
     ) {
-
-   /// Chirag : Commented modelInfo not getting proper value  but its optional
-   /// Chirag: Gender value getting from userBodyProfile, not getting from storeProduct.storeProductMeta?.additionalInfo
        let additionalInfo = [
             "brand": VirtusizeAnyCodable(
                 storeProduct.storeProductMeta?.additionalInfo?.brand ?? storeProduct.storeProductMeta?.brand ?? ""
@@ -62,7 +59,7 @@ internal struct VirtusizeGetSizeParams: Codable {
             "sizes": VirtusizeAnyCodable(
                 storeProduct.storeProductMeta?.additionalInfo?.sizes ?? [:]
             ),
-
+            "model_info": VirtusizeAnyCodable(getModelInfoDict(storeProduct: storeProduct)),
             "gender": VirtusizeAnyCodable(
                 userBodyProfile?.gender ?? nil
             )
@@ -79,13 +76,20 @@ internal struct VirtusizeGetSizeParams: Codable {
             userWeight = Float(weight)
         }
 
-        items = [VirtusizeGetSizeItemsParam(additionalInfo: additionalInfo, itemSizesOrig: itemSizesOrig, productType: productType, extProductId: storeProduct.externalId)]
+        items = [
+            VirtusizeGetSizeItemsParam(
+                additionalInfo: additionalInfo,
+                itemSizesOrig: itemSizesOrig,
+                productType: productType,
+                extProductId: storeProduct.externalId
+            )
+        ]
 
     }
 }
 
 	/// Gets the dictionary of the model info
-	private func getModelInfoDict(storeProduct: VirtusizeServerProduct) -> [String: Any] {
+	private func getModelInfoDict(storeProduct: VirtusizeServerProduct) -> [String: Any]? {
 		var modelInfoDict: [String: Any] = [:]
 		if let modelInfo = storeProduct.storeProductMeta?.additionalInfo?.modelInfo {
 			for (name, measurement) in modelInfo {
@@ -96,7 +100,7 @@ internal struct VirtusizeGetSizeParams: Codable {
 				}
 			}
 		}
-		return modelInfoDict
+        return modelInfoDict.isEmpty ? nil : modelInfoDict
 	}
 
 	/// Gets the dictionary of the user body data

--- a/Virtusize/Sources/Internal/Models/VirtusizeProductCheckData.swift
+++ b/Virtusize/Sources/Internal/Models/VirtusizeProductCheckData.swift
@@ -22,7 +22,7 @@
 //  THE SOFTWARE.
 //
 
-/// This class represents the response for the API request `productDataCheck`
+/// This class represents the response for the API request `productCheck`
 internal class VirtusizeProductCheckData: Codable {
 	let validProduct: Bool
 	let fetchMetaData: Bool

--- a/Virtusize/Sources/Models/VirtusizeEnvironment.swift
+++ b/Virtusize/Sources/Models/VirtusizeEnvironment.swift
@@ -34,7 +34,7 @@ public enum VirtusizeEnvironment: String, CaseIterable {
 		return self == .GLOBAL || self == .JAPAN || self == .KOREA
 	}
 
-	/// Gets the services URL for the `productDataCheck` and `getSize` requests
+	/// Gets the services URL for the `productCheck` and `getSize` requests
 	internal func servicesUrl() -> String {
 		// swiftlint:disable switch_case_alignment
 		switch self {

--- a/Virtusize/Sources/Models/VirtusizeParams.swift
+++ b/Virtusize/Sources/Models/VirtusizeParams.swift
@@ -78,9 +78,6 @@ public class VirtusizeParams {
 		paramsScript += "\(ParamKey.browserID): '\(UserDefaultsHelper.current.identifier)', "
 		paramsScript += "\(ParamKey.sessionData): \(userSessionResponse), "
 		paramsScript += "\(ParamKey.externalProductID): '\(externalProductId)', "
-		if let userId = Virtusize.userID {
-			paramsScript += "\(ParamKey.externalUserID): '\(userId)', "
-		}
 		paramsScript += "\(ParamKey.showSGI): \(showSGI), "
 		paramsScript += "\(ParamKey.allowedLanguages): \(getAllowedLanguagesScript(allowedLanguages)), "
 		paramsScript += "\(ParamKey.detailsPanelCards): \(detailsPanelCards.map { category in category.rawValue }), "

--- a/Virtusize/Sources/Models/VirtusizeProduct.swift
+++ b/Virtusize/Sources/Models/VirtusizeProduct.swift
@@ -37,7 +37,7 @@ public class VirtusizeProduct: Codable {
 	/// The URL of the product image that is fully qualified with the domain and the protocol
 	public var imageURL: URL?
 
-	/// The product data from the response of the `productDataCheck` request
+	/// The product data from the response of the `productCheck` request
 	internal var productCheckData: VirtusizeProductCheckData?
 
 	/// The product data as a `JSONObject`

--- a/Virtusize/Sources/Models/VirtusizeServerProduct.swift
+++ b/Virtusize/Sources/Models/VirtusizeServerProduct.swift
@@ -147,11 +147,11 @@ public class VirtusizeServerProduct: Codable {
 		_ sizeComparisonRecommendedSize: SizeComparisonRecommendedSize?,
 		_ bodyProfileRecommendedSizeName: String?
 	) -> String {
+        if bodyProfileRecommendedSizeName != nil {
+            return i18nLocalization.getOneSizeBodyProfileText()
+        }
 		if let sizeComparisonRecommendedSize = sizeComparisonRecommendedSize, sizeComparisonRecommendedSize.isValid() {
 			return i18nLocalization.getOneSizeProductComparisonText(sizeComparisonRecommendedSize)
-		}
-		if bodyProfileRecommendedSizeName != nil {
-			return i18nLocalization.getOneSizeBodyProfileText()
 		}
 		return i18nLocalization.getNoDataText()
 	}
@@ -162,11 +162,11 @@ public class VirtusizeServerProduct: Codable {
 		_ sizeComparisonRecommendedSize: SizeComparisonRecommendedSize?,
 		_ bodyProfileRecommendedSizeName: String?
 	) -> String {
+        if let bodyProfileRecommendedSizeName = bodyProfileRecommendedSizeName {
+            return i18nLocalization.getMultiSizeBodyProfileText(bodyProfileRecommendedSizeName)
+        }
 		if let sizeComparisonRecommendedSizeName = sizeComparisonRecommendedSize?.bestStoreProductSize?.name {
 			return i18nLocalization.getMultiSizeProductionComparisonText(sizeComparisonRecommendedSizeName)
-		}
-		if let bodyProfileRecommendedSizeName = bodyProfileRecommendedSizeName {
-			return i18nLocalization.getMultiSizeBodyProfileText(bodyProfileRecommendedSizeName)
 		}
 		return i18nLocalization.getNoDataText()
 	}

--- a/Virtusize/Sources/UI/VirtusizeButton.swift
+++ b/Virtusize/Sources/UI/VirtusizeButton.swift
@@ -69,8 +69,8 @@ public class VirtusizeButton: UIButton, VirtusizeView, VirtusizeViewEventProtoco
 	private func addNotificationObserver() {
 		NotificationCenter.default.addObserver(
 			self,
-			selector: #selector(didReceiveProductDataCheck(_:)),
-			name: .productDataCheck,
+			selector: #selector(didReceiveProductCheckData(_:)),
+			name: .productCheckData,
 			object: Virtusize.self
 		)
 
@@ -82,8 +82,8 @@ public class VirtusizeButton: UIButton, VirtusizeView, VirtusizeViewEventProtoco
 		)
 	}
 
-	@objc func didReceiveProductDataCheck(_ notification: Notification) {
-		shouldUpdateProductDataCheckData(notification) { productWithPDCData in
+	@objc func didReceiveProductCheckData(_ notification: Notification) {
+		shouldUpdateProductCheckData(notification) { productWithPDCData in
 			self.clientProduct = productWithPDCData
 			isHidden = false
 		}

--- a/Virtusize/Sources/UI/VirtusizeButton.swift
+++ b/Virtusize/Sources/UI/VirtusizeButton.swift
@@ -171,4 +171,8 @@ extension VirtusizeButton: VirtusizeEventHandler {
 	public func clearUserData() {
 		handleClearUserData()
 	}
+
+    public func userClosedWidget() {
+        handleUserClosedWidget()
+    }
 }

--- a/Virtusize/Sources/UI/VirtusizeInPageView.swift
+++ b/Virtusize/Sources/UI/VirtusizeInPageView.swift
@@ -61,8 +61,8 @@ public class VirtusizeInPageView: UIView, VirtusizeView, VirtusizeViewEventProto
 	private func addNotificationObserver() {
 		NotificationCenter.default.addObserver(
 			self,
-			selector: #selector(didReceiveProductDataCheck(_:)),
-			name: .productDataCheck,
+			selector: #selector(didReceiveProductCheckData(_:)),
+			name: .productCheckData,
 			object: Virtusize.self
 		)
 
@@ -88,8 +88,8 @@ public class VirtusizeInPageView: UIView, VirtusizeView, VirtusizeViewEventProto
 		)
 	}
 
-	@objc internal func didReceiveProductDataCheck(_ notification: Notification) {
-		shouldUpdateProductDataCheckData(notification) { productWithPDCData in
+	@objc internal func didReceiveProductCheckData(_ notification: Notification) {
+		shouldUpdateProductCheckData(notification) { productWithPDCData in
 			self.clientProduct = productWithPDCData
 			isHidden = false
 			setLoadingScreen(loading: true)

--- a/Virtusize/Sources/UI/VirtusizeInPageView.swift
+++ b/Virtusize/Sources/UI/VirtusizeInPageView.swift
@@ -232,4 +232,8 @@ extension VirtusizeInPageView: VirtusizeEventHandler {
 	public func clearUserData() {
 		handleClearUserData()
 	}
+
+    public func userClosedWidget() {
+        handleUserClosedWidget()
+    }
 }

--- a/Virtusize/Sources/UI/VirtusizeNotification.swift
+++ b/Virtusize/Sources/UI/VirtusizeNotification.swift
@@ -25,14 +25,14 @@
 import Foundation
 
 extension Notification.Name {
-	static let productDataCheck = Notification.Name(NotificationKey.productDataCheck)
+	static let productCheckData = Notification.Name(NotificationKey.productCheckData)
 	static let storeProduct = Notification.Name(NotificationKey.storeProduct)
 	static let sizeRecommendationData = Notification.Name(NotificationKey.sizeRecommendationData)
 	static let inPageError = Notification.Name(NotificationKey.inPageError)
 }
 
 struct NotificationKey {
-	static let productDataCheck = "productDataCheck"
+	static let productCheckData = "productCheckData"
 	static let storeProduct = "storeProduct"
 	static let sizeRecommendationData = "sizeRecommendationData"
 	static let inPageError = "inPageError"

--- a/Virtusize/Sources/UI/VirtusizeView.swift
+++ b/Virtusize/Sources/UI/VirtusizeView.swift
@@ -53,16 +53,16 @@ extension VirtusizeView {
 		}
 	}
 
-	internal func shouldUpdateProductDataCheckData(
+	internal func shouldUpdateProductCheckData(
 		_ notification: Notification,
-		onProductDataCheckData: (VirtusizeProduct) -> Void
+		onProductCheckData: (VirtusizeProduct) -> Void
 	) {
 		guard let notificationData = notification.userInfo as? [String: Any],
-			let productWithPDCData = notificationData[NotificationKey.productDataCheck] as? VirtusizeProduct,
+			let productWithPDCData = notificationData[NotificationKey.productCheckData] as? VirtusizeProduct,
 			productWithPDCData.externalId == self.clientProduct?.externalId else {
 			return
 		}
-		onProductDataCheckData(productWithPDCData)
+		onProductCheckData(productWithPDCData)
 	}
 
 	internal func shouldUpdateStoreProduct(

--- a/Virtusize/Sources/UI/VirtusizeViewEventProtocol.swift
+++ b/Virtusize/Sources/UI/VirtusizeViewEventProtocol.swift
@@ -102,7 +102,7 @@ extension VirtusizeViewEventProtocol {
 			VirtusizeRepository.shared.updateInPageRecommendation()
 		}
 	}
-    
+
     public func handleUserClosedWidget() {
         Virtusize.dispatchQueue.async {
             VirtusizeRepository.shared.updateUserSession()

--- a/Virtusize/Sources/UI/VirtusizeViewEventProtocol.swift
+++ b/Virtusize/Sources/UI/VirtusizeViewEventProtocol.swift
@@ -102,4 +102,10 @@ extension VirtusizeViewEventProtocol {
 			VirtusizeRepository.shared.updateInPageRecommendation()
 		}
 	}
+    
+    public func handleUserClosedWidget() {
+        Virtusize.dispatchQueue.async {
+            VirtusizeRepository.shared.updateUserSession()
+        }
+    }
 }

--- a/Virtusize/Sources/UI/VirtusizeViewEventProtocol.swift
+++ b/Virtusize/Sources/UI/VirtusizeViewEventProtocol.swift
@@ -95,10 +95,7 @@ extension VirtusizeViewEventProtocol {
 		Virtusize.dispatchQueue.async {
 			VirtusizeRepository.shared.clearUserData()
 			VirtusizeRepository.shared.updateUserSession()
-			VirtusizeRepository.shared.fetchDataForInPageRecommendation(
-				shouldUpdateUserProducts: false,
-				shouldUpdateBodyProfile: false
-			)
+			VirtusizeRepository.shared.fetchDataForInPageRecommendation()
 			VirtusizeRepository.shared.updateInPageRecommendation()
 		}
 	}

--- a/Virtusize/Sources/UI/VirtusizeWebViewController.swift
+++ b/Virtusize/Sources/UI/VirtusizeWebViewController.swift
@@ -299,6 +299,7 @@ extension VirtusizeWebViewController: WKScriptMessageHandler {
 				case .userLoggedOut, .userDeletedData:
 					eventHandler?.clearUserData()
 				case .userClosedWidget:
+                    eventHandler?.userClosedWidget()
 					shouldClose()
 				default:
 					break

--- a/Virtusize/Sources/Virtusize.swift
+++ b/Virtusize/Sources/Virtusize.swift
@@ -48,11 +48,11 @@ public class Virtusize {
 	public static var processPool: WKProcessPool?
 
 	/// NotificationCenter observers for debugging the initial product data check
-	/// - `Virtusize.productDataCheckDidFail`, the `UserInfo` will contain a message
+	/// - `Virtusize.productCheckDidFail`, the `UserInfo` will contain a message
 	/// with the cause of the failure
-	/// - `Virtusize.productDataCheckDidSucceed`
-	public static var productDataCheckDidFail = Notification.Name("VirtusizeProductDataCheckDidFail")
-	public static var productDataCheckDidSucceed = Notification.Name("VirtusizeProductDataCheckDidSucceed")
+	/// - `Virtusize.productCheckDidSucceed`
+	public static var productCheckDidFail = Notification.Name("VirtusizeProductCheckDidFail")
+	public static var productCheckDidSucceed = Notification.Name("VirtusizeProductCheckDidSucceed")
 
 	/// The singleton instance of `VirtusizeRepository`
 	private static var virtusizeRepository = VirtusizeRepository.shared
@@ -119,9 +119,9 @@ public class Virtusize {
                     virtusizeRepository.updateUserSession()
 					DispatchQueue.main.async {
 						NotificationCenter.default.post(
-							name: .productDataCheck,
+							name: .productCheckData,
 							object: Virtusize.self,
-							userInfo: [NotificationKey.productDataCheck: productWithPDCData]
+							userInfo: [NotificationKey.productCheckData: productWithPDCData]
 						)
 					}
 					virtusizeRepository.fetchInitialData(

--- a/Virtusize/Sources/Virtusize.swift
+++ b/Virtusize/Sources/Virtusize.swift
@@ -34,7 +34,7 @@ public class Virtusize {
 
 	/// The user id that is the unique user id from the client system
     public static var userID: String? {
-        didSet{
+        didSet {
             APICache.shared.currentUserId = Virtusize.userID
         }
     }

--- a/Virtusize/Sources/Virtusize.swift
+++ b/Virtusize/Sources/Virtusize.swift
@@ -33,7 +33,11 @@ public class Virtusize {
 	public static var APIKey: String?
 
 	/// The user id that is the unique user id from the client system
-	public static var userID: String?
+    public static var userID: String? {
+        didSet{
+            APICache.shared.currentUserId = Virtusize.userID
+        }
+    }
 
 	/// The Virtusize environment that defaults to the `GLOBAL` domain
 	public static var environment = VirtusizeEnvironment.GLOBAL

--- a/Virtusize/Sources/VirtusizeEventHandler.swift
+++ b/Virtusize/Sources/VirtusizeEventHandler.swift
@@ -34,4 +34,5 @@ public protocol VirtusizeEventHandler {
 	func userDeletedProduct(userProductId: Int?)
 	func userUpdatedBodyMeasurements(recommendedSize: String?)
 	func userChangedRecommendationType(changedType: SizeRecommendationType?)
+    func userClosedWidget()
 }

--- a/Virtusize/Sources/VirtusizeRepository.swift
+++ b/Virtusize/Sources/VirtusizeRepository.swift
@@ -45,7 +45,7 @@ internal class VirtusizeRepository: NSObject {
 	private var userProducts: [VirtusizeServerProduct]?
 	private var userBodyProfile: VirtusizeUserBodyProfile?
 	private var sizeComparisonRecommendedSize: SizeComparisonRecommendedSize?
-	private var bodyProfileRecommendedSizes: BodyProfileRecommendedSizeArray?
+    private var bodyProfileRecommendedSize: BodyProfileRecommendedSize?
 
 	/// A set to cache the store product information of all the visited products
 	private var serverStoreProductSet: Set<VirtusizeServerProduct> = []
@@ -195,11 +195,11 @@ internal class VirtusizeRepository: NSObject {
  		}
 
 		if let userBodyProfile = userBodyProfile {
-			bodyProfileRecommendedSizes = VirtusizeAPIService.getBodyProfileRecommendedSizesAsync(
+            bodyProfileRecommendedSize = VirtusizeAPIService.getBodyProfileRecommendedSizesAsync(
 				productTypes: productTypes!,
 				storeProduct: storeProduct,
 				userBodyProfile: userBodyProfile
-			).success
+            ).success?.first
 		}
 
 		var userProducts = self.userProducts ?? []
@@ -220,7 +220,7 @@ internal class VirtusizeRepository: NSObject {
 		userProducts = nil
 		sizeComparisonRecommendedSize = nil
 		userBodyProfile = nil
-		bodyProfileRecommendedSizes = nil
+        bodyProfileRecommendedSize = nil
 	}
 
 	/// Updates the user session by calling the session API
@@ -271,9 +271,9 @@ internal class VirtusizeRepository: NSObject {
 			case .compareProduct:
 				Virtusize.sizeRecData = (product, sizeComparisonRecommendedSize, nil)
 			case .body:
-            Virtusize.sizeRecData = (product, nil, bodyProfileRecommendedSizes?.first)
+            Virtusize.sizeRecData = (product, nil, bodyProfileRecommendedSize)
 			default:
-            Virtusize.sizeRecData = (product, sizeComparisonRecommendedSize, bodyProfileRecommendedSizes?.first)
+            Virtusize.sizeRecData = (product, sizeComparisonRecommendedSize, bodyProfileRecommendedSize)
 		}
 	}
 
@@ -284,7 +284,7 @@ internal class VirtusizeRepository: NSObject {
 		guard let recommendedSize = recommendedSize else {
 			return
 		}
-        bodyProfileRecommendedSizes?.append(BodyProfileRecommendedSize(sizeName: recommendedSize))
+        bodyProfileRecommendedSize = BodyProfileRecommendedSize(sizeName: recommendedSize)
 	}
 
 	/// Removes the deleted user product by the product ID from the user product list

--- a/Virtusize/Sources/VirtusizeRepository.swift
+++ b/Virtusize/Sources/VirtusizeRepository.swift
@@ -54,19 +54,19 @@ internal class VirtusizeRepository: NSObject {
 	///
 	/// - Parameters:
 	///   - product: `VirtusizeProduct`
-	///   - onProductDataCheck: a closure to pass a valid`VirtusizeProduct` with the PDC data back
+	///   - onProductCheckData: a closure to pass a valid`VirtusizeProduct` with the PDC data back
 	internal func checkProductValidity(
 		product: VirtusizeProduct,
-		onProductDataCheck: ((VirtusizeProduct?) -> Void)? = nil
+		onProductCheckData: ((VirtusizeProduct?) -> Void)? = nil
 	) {
 		let productResponse = VirtusizeAPIService.productCheckAsync(product: product)
 		guard let product = productResponse.success else {
 			NotificationCenter.default.post(
-				name: Virtusize.productDataCheckDidFail,
+				name: Virtusize.productCheckDidFail,
 				object: Virtusize.self,
 				userInfo: ["message": productResponse.string ?? VirtusizeError.unknownError.debugDescription]
 			)
-			onProductDataCheck?(nil)
+			onProductCheckData?(nil)
 			return
 		}
 
@@ -83,11 +83,11 @@ internal class VirtusizeRepository: NSObject {
 
 		guard mutableProduct.productCheckData?.productDataId != nil else {
 			NotificationCenter.default.post(
-				name: Virtusize.productDataCheckDidFail,
+				name: Virtusize.productCheckDidFail,
 				object: Virtusize.self,
 				userInfo: ["message": mutableProduct.dictionary]
 			)
-			onProductDataCheck?(nil)
+			onProductCheckData?(nil)
 			return
 		}
 
@@ -105,12 +105,12 @@ internal class VirtusizeRepository: NSObject {
 		)
 
 		NotificationCenter.default.post(
-			name: Virtusize.productDataCheckDidSucceed,
+			name: Virtusize.productCheckDidSucceed,
 			object: Virtusize.self,
 			userInfo: ["message": mutableProduct.dictionary]
 		)
 
-		onProductDataCheck?(mutableProduct)
+		onProductCheckData?(mutableProduct)
 	}
 
 	/// Fetches the initial data such as store product info, product type lists and i18 localization
@@ -266,16 +266,16 @@ internal class VirtusizeRepository: NSObject {
 		guard let product = product ?? lastProductOnVirtusizeWebView else {
 			return
 		}
-		// swiftlint:disable switch_case_alignment
-		switch type {
-			case .compareProduct:
-				Virtusize.sizeRecData = (product, sizeComparisonRecommendedSize, nil)
-			case .body:
-            Virtusize.sizeRecData = (product, nil, bodyProfileRecommendedSize)
-			default:
-            Virtusize.sizeRecData = (product, sizeComparisonRecommendedSize, bodyProfileRecommendedSize)
-		}
-	}
+        // swiftlint:disable switch_case_alignment
+        switch type {
+            case .compareProduct:
+                Virtusize.sizeRecData = (product, sizeComparisonRecommendedSize, nil)
+            case .body:
+                Virtusize.sizeRecData = (product, nil, bodyProfileRecommendedSize)
+            default:
+                Virtusize.sizeRecData = (product, sizeComparisonRecommendedSize, bodyProfileRecommendedSize)
+        }
+    }
 
 	/// Updates the user body recommended size
 	///

--- a/Virtusize/Tests/APIEndpointsTests.swift
+++ b/Virtusize/Tests/APIEndpointsTests.swift
@@ -39,8 +39,8 @@ class APIEndpointsTests: XCTestCase {
         // Put teardown code here. This method is called after the invocation of each test method in the class.
     }
 
-    func testProductDataCheckEndpoint_returnExpectedComponents() {
-        let endpoint = APIEndpoints.productDataCheck(externalId: dummyExternalId)
+    func testProductCheckEndpoint_returnExpectedComponents() {
+        let endpoint = APIEndpoints.productCheck(externalId: dummyExternalId)
 
         XCTAssertEqual(endpoint.components.host, "services.virtusize.com")
         XCTAssertEqual(endpoint.components.path, "/stg/product/check")

--- a/Virtusize/Tests/APIEventTests.swift
+++ b/Virtusize/Tests/APIEventTests.swift
@@ -56,19 +56,19 @@ class APIEventTests: XCTestCase {
         XCTAssertEqual(payloadJson?["snippetVersion"], "2.6.4")
     }
 
-    func testAPIEvent_alignProductDataCheckContext_hasExpectedPayload() {
-        let data = TestFixtures.productDataCheckJsonResponse.data(using: .utf8)!
-        let productDataCheckJsonObject = try? JSONSerialization.jsonObject(with: data, options: []) as? JSONObject
+    func testAPIEvent_alignProductCheckDataContext_hasExpectedPayload() {
+        let data = TestFixtures.productCheckJsonResponse.data(using: .utf8)!
+        let productCheckJsonObject = try? JSONSerialization.jsonObject(with: data, options: []) as? JSONObject
 
-        event?.align(withContext: productDataCheckJsonObject)
+        event?.align(withContext: productCheckJsonObject)
 
-        let productDataCheckPayloadJson = try? JSONSerialization.jsonObject(
+        let productCheckPayloadJson = try? JSONSerialization.jsonObject(
             with: event!.jsonPayload!, options: []) as? JSONObject
 
-        XCTAssertEqual(productDataCheckPayloadJson?["storeId"] as? Int ?? -1, 2)
-        XCTAssertEqual(productDataCheckPayloadJson?["storeName"] as? String ?? "", "virtusize")
-        XCTAssertEqual(productDataCheckPayloadJson?["storeProductType"] as? String ?? "", "pants")
-        XCTAssertEqual(productDataCheckPayloadJson?["storeProductExternalId"] as? String ?? "", "694")
+        XCTAssertEqual(productCheckPayloadJson?["storeId"] as? Int ?? -1, 2)
+        XCTAssertEqual(productCheckPayloadJson?["storeName"] as? String ?? "", "virtusize")
+        XCTAssertEqual(productCheckPayloadJson?["storeProductType"] as? String ?? "", "pants")
+        XCTAssertEqual(productCheckPayloadJson?["storeProductExternalId"] as? String ?? "", "694")
     }
 
     func testAPIEvent_alignAddtionalEventData_hasExpectedPayload() {

--- a/Virtusize/Tests/APIRequestTests.swift
+++ b/Virtusize/Tests/APIRequestTests.swift
@@ -191,11 +191,11 @@ class APIRequestTests: XCTestCase {
             ]
         )
         XCTAssertEqual(
-            (actualParams?.items.first?.additionalInfo["model_info"]?.value as? [String: Any])?["size"] as? String,
+            (actualParams?.items.first?.additionalInfo["modelInfo"]?.value as? [String: Any])?["size"] as? String,
             "38"
         )
         XCTAssertEqual(
-            (actualParams?.items.first?.additionalInfo["model_info"]?.value as? [String: Any])?["hip"] as? Int,
+            (actualParams?.items.first?.additionalInfo["modelInfo"]?.value as? [String: Any])?["hip"] as? Int,
             85
         )
         XCTAssertEqual(actualParams?.items.first?.additionalInfo["brand"]?.value as? String, "Virtusize")

--- a/Virtusize/Tests/APIRequestTests.swift
+++ b/Virtusize/Tests/APIRequestTests.swift
@@ -161,15 +161,15 @@ class APIRequestTests: XCTestCase {
         let apiRequest = APIRequest.getBodyProfileRecommendedSize(
             productTypes: TestFixtures.getProductTypes(),
             storeProduct: storeProduct,
-            userBodyProfile: userBodyProfile)
+            userBodyProfile: userBodyProfile
+        )
 
         XCTAssertEqual(apiRequest?.httpMethod, APIMethod.post.rawValue)
         XCTAssertEqual(apiRequest?.allHTTPHeaderFields?["x-vs-bid"] ?? "", UserDefaultsHelper.current.identifier)
         XCTAssertNotNil(apiRequest?.httpBody)
         let actualParams = try? JSONDecoder().decode(VirtusizeGetSizeParams.self, from: apiRequest!.httpBody!)
         XCTAssertNotNil(actualParams)
-        XCTAssertEqual(actualParams?.items.first?.additionalInfo.count, 4)
-
+        XCTAssertEqual(actualParams?.items.first?.additionalInfo.count, 5)
         XCTAssertEqual(actualParams?.items.first?.additionalInfo["gender"]?.value as? String, "female")
         XCTAssertEqual(
             actualParams?.items.first?.additionalInfo["sizes"]?.value as? [String: [String: Int?]],
@@ -190,7 +190,14 @@ class APIRequestTests: XCTestCase {
             ]
             ]
         )
-
+        XCTAssertEqual(
+            (actualParams?.items.first?.additionalInfo["model_info"]?.value as? [String: Any])?["size"] as? String,
+            "38"
+        )
+        XCTAssertEqual(
+            (actualParams?.items.first?.additionalInfo["model_info"]?.value as? [String: Any])?["hip"] as? Int,
+            85
+        )
         XCTAssertEqual(actualParams?.items.first?.additionalInfo["brand"]?.value as? String, "Virtusize")
         XCTAssertEqual(actualParams?.items.first?.additionalInfo["fit"]?.value as? String, "regular")
         XCTAssertEqual(actualParams?.bodyData.count, 22)
@@ -207,5 +214,4 @@ class APIRequestTests: XCTestCase {
 			"https://size-recommendation.virtusize.com/item"
 		)
     }
-
 }

--- a/Virtusize/Tests/TestFixtures.swift
+++ b/Virtusize/Tests/TestFixtures.swift
@@ -35,7 +35,7 @@ struct TestFixtures {
 
     static let notFoundResponse = "{\"detail\": \"Not found.\"}"
 
-    static let productDataCheckJsonResponse =
+    static let productCheckJsonResponse =
     """
         {
             "data":{

--- a/Virtusize/Tests/VirtusizeAPIServiceTests.swift
+++ b/Virtusize/Tests/VirtusizeAPIServiceTests.swift
@@ -56,10 +56,10 @@ class VirtusizeAPIServiceTests: XCTestCase {
         XCTAssertEqual(actualVersion, VirtusizeConfiguration.defaultAoyamaVersion)
     }
 
-    func testProductDataCheck_hasExpectedCallbackData() {
+    func testProductCheck_hasExpectedCallbackData() {
         let expectation = self.expectation(description: "Virtusize.productCheck reaches the callback")
         var actualProduct: VirtusizeProduct?
-        VirtusizeAPIService.session = MockURLSession(data: TestFixtures.productDataCheckJsonResponse.data(using: .utf8),
+        VirtusizeAPIService.session = MockURLSession(data: TestFixtures.productCheckJsonResponse.data(using: .utf8),
                                                      urlResponse: nil,
                                                      error: nil)
         DispatchQueue.global().async {

--- a/Virtusize/Tests/VirtusizeGetSizeParamsTests.swift
+++ b/Virtusize/Tests/VirtusizeGetSizeParamsTests.swift
@@ -47,22 +47,30 @@ class VirtusizeGetSizeParamsTests: XCTestCase {
                             "brand": "Virtusize",
                             "fit": "regular",
                             "sizes": {
-                            "35": {
-                                "sleeve": 805,
-                                "bust": 630,
-                                "height": 740
+                                "35": {
+                                    "sleeve": 805,
+                                    "bust": 630,
+                                    "height": 740
+                                },
+                                "36": {
+                                    "sleeve": 825,
+                                    "bust": 645,
+                                    "height": 750
+                                },
+                                "37": {
+                                    "sleeve": 845,
+                                    "bust": 660,
+                                    "height": 760
+                                }
                             },
-                            "36": {
-                                "sleeve": 825,
-                                "bust": 645,
-                                "height": 750
+                            "gender": "female",
+                            "model_info": {
+                                "hip": 85,
+                                "size": "38",
+                                "bust": 78,
+                                "waist": 56,
+                                "height": 165
                             },
-                            "37": {
-                                "sleeve": 845,
-                                "bust": 660,
-                                "height": 760
-                            }},
-                            "gender": "female"
                         },
                         "itemSizesOrig": {
                             "35": {
@@ -215,27 +223,28 @@ class VirtusizeGetSizeParamsTests: XCTestCase {
             )!,
             userBodyProfile: nil
         )
-
         let expectedGetSizeParamsData = Data(
-        """
-        {
-            "bodyData": {},
-            "items": [
-                {
-                    "additionalInfo": {
-                        "brand": "",
-                        "fit": "regular",
-                        "sizes": {},
-                        "gender": null
-                    },
-                    "itemSizesOrig": {},
-                    "productType": "",
-                    "extProductId": "694"
-                }
-            ],
-            "userGender": ""
-        }
-""".utf8)
+            """
+            {
+                "bodyData": {},
+                "items": [
+                    {
+                        "additionalInfo": {
+                            "brand": "",
+                            "fit": "regular",
+                            "sizes": {},
+                            "model_info": null,
+                            "gender": null
+                        },
+                        "itemSizesOrig": {},
+                        "productType": "",
+                        "extProductId": "694"
+                    }
+                ],
+                "userGender": ""
+            }
+            """.utf8
+        )
 
         guard let expectedJsonObject = try? JSONSerialization.jsonObject(
                 with: expectedGetSizeParamsData, options: []

--- a/Virtusize/Tests/VirtusizeGetSizeParamsTests.swift
+++ b/Virtusize/Tests/VirtusizeGetSizeParamsTests.swift
@@ -64,7 +64,7 @@ class VirtusizeGetSizeParamsTests: XCTestCase {
                                 }
                             },
                             "gender": "female",
-                            "model_info": {
+                            "modelInfo": {
                                 "hip": 85,
                                 "size": "38",
                                 "bust": 78,
@@ -233,7 +233,7 @@ class VirtusizeGetSizeParamsTests: XCTestCase {
                             "brand": "",
                             "fit": "regular",
                             "sizes": {},
-                            "model_info": null,
+                            "modelInfo": null,
                             "gender": null
                         },
                         "itemSizesOrig": {},

--- a/VirtusizeCore/Sources/API/APIRequest.swift
+++ b/VirtusizeCore/Sources/API/APIRequest.swift
@@ -60,6 +60,9 @@ public struct APIRequest {
 	public static func apiRequest(components: URLComponents, method: APIMethod = .get) -> URLRequest {
 		var request = HTTPRequest(components: components, method: method)
 		request.addValue(UserDefaultsHelper.current.identifier, forHTTPHeaderField: "x-vs-bid")
+        if let storeId = APIService.currentStoreId {
+            request.addValue(String(storeId), forHTTPHeaderField: "x-vs-store-id")
+        }
 		return request
 	}
 

--- a/VirtusizeCore/Sources/API/APIRequest.swift
+++ b/VirtusizeCore/Sources/API/APIRequest.swift
@@ -60,8 +60,11 @@ public struct APIRequest {
 	public static func apiRequest(components: URLComponents, method: APIMethod = .get) -> URLRequest {
 		var request = HTTPRequest(components: components, method: method)
 		request.addValue(UserDefaultsHelper.current.identifier, forHTTPHeaderField: "x-vs-bid")
-        if let storeId = APIService.currentStoreId {
+        if let storeId = APICache.shared.currentStoreId {
             request.addValue(String(storeId), forHTTPHeaderField: "x-vs-store-id")
+        }
+        if let userId = APICache.shared.currentUserId, let authToken = UserDefaultsHelper.current.authToken, !authToken.isEmpty {
+            request.addValue(userId, forHTTPHeaderField: "x-vs-external-user-id")
         }
 		return request
 	}

--- a/VirtusizeCore/Sources/API/APIService.swift
+++ b/VirtusizeCore/Sources/API/APIService.swift
@@ -44,9 +44,6 @@ open class APIService {
 		delegateQueue: nil
 	)
 
-    /// Cached Store ID
-    public static var currentStoreId: Int?
-
 	/// Performs an API request.
 	///
 	/// - Parameters:

--- a/VirtusizeCore/Sources/API/APIService.swift
+++ b/VirtusizeCore/Sources/API/APIService.swift
@@ -44,6 +44,9 @@ open class APIService {
 		delegateQueue: nil
 	)
 
+    /// Cached Store ID
+    public static var currentStoreId: Int?
+
 	/// Performs an API request.
 	///
 	/// - Parameters:

--- a/VirtusizeCore/Sources/APICache.swift
+++ b/VirtusizeCore/Sources/APICache.swift
@@ -1,0 +1,36 @@
+//
+//  APICache.swift
+//
+//  Copyright (c) 2024 Virtusize KK
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
+
+import Foundation
+
+public class APICache {
+    
+    public static let shared = APICache()
+    
+    /// Cached user ID
+    public var currentUserId: String?
+
+    /// Cached Store ID
+    public var currentStoreId: Int?
+}

--- a/VirtusizeCore/VirtusizeCore.xcodeproj/project.pbxproj
+++ b/VirtusizeCore/VirtusizeCore.xcodeproj/project.pbxproj
@@ -23,6 +23,7 @@
 		9C35067327280367003BEF82 /* APIResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C35067227280367003BEF82 /* APIResponse.swift */; };
 		9C35067527280396003BEF82 /* HTTPURLResponse+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C35067427280396003BEF82 /* HTTPURLResponse+Extensions.swift */; };
 		9C6E36C72739616E00608640 /* UserDefaultsHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C6E36C52739616900608640 /* UserDefaultsHelperTests.swift */; };
+		9CAD1F4C2CF4AB6E00AC104E /* APICache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CAD1F4B2CF4AB6E00AC104E /* APICache.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -57,6 +58,7 @@
 		9C35067227280367003BEF82 /* APIResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = APIResponse.swift; path = API/APIResponse.swift; sourceTree = "<group>"; };
 		9C35067427280396003BEF82 /* HTTPURLResponse+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "HTTPURLResponse+Extensions.swift"; sourceTree = "<group>"; };
 		9C6E36C52739616900608640 /* UserDefaultsHelperTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserDefaultsHelperTests.swift; sourceTree = "<group>"; };
+		9CAD1F4B2CF4AB6E00AC104E /* APICache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APICache.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -163,6 +165,7 @@
 				9C35067027280326003BEF82 /* APISessionProtocol.swift */,
 				9C3506652727FEBD003BEF82 /* APIRequest.swift */,
 				9C35066A27280222003BEF82 /* APIService.swift */,
+				9CAD1F4B2CF4AB6E00AC104E /* APICache.swift */,
 			);
 			name = API;
 			sourceTree = "<group>";
@@ -330,6 +333,7 @@
 				9C3506692727FF4B003BEF82 /* UserDefaultsHelper.swift in Sources */,
 				9C35062F2727B782003BEF82 /* BundleLoaderProtocal.swift in Sources */,
 				9C35067527280396003BEF82 /* HTTPURLResponse+Extensions.swift in Sources */,
+				9CAD1F4C2CF4AB6E00AC104E /* APICache.swift in Sources */,
 				9C35062E2727B781003BEF82 /* VirtusizeCoreBundleLoader.swift in Sources */,
 				9C35067127280326003BEF82 /* APISessionProtocol.swift in Sources */,
 				9C3506662727FEBD003BEF82 /* APIRequest.swift in Sources */,


### PR DESCRIPTION
## 🔗 Related Links

- [x] [ClickUp](https://app.clickup.com/t/3702259/NSDK-240)
- [x] [ClickUp](https://app.clickup.com/t/3702259/NSDK-238)
- [x] [ClickUp](https://app.clickup.com/t/3702259/NSDK-241)
- [x] [ClickUp](https://app.clickup.com/t/3702259/NSDK-242)

## ⬅️ As Is

- [NSDK-240] Inpage doesn’t recommend anything after coming back to PDP from Comparison screen
- [NSDK-238] Inpage text for on-boarding user has 2 patterns at random
- [NSDK-241] Inpage shows different size from that VS widget shows
- [NSDK-242] Body data tuning is not saved once closing the widget

## ➡️ To Be

- [x] Fixed [NSDK-240] Inpage doesn’t recommend anything after coming back to PDP from Comparison screen

https://github.com/user-attachments/assets/a189d162-437a-49d9-9191-1692401d51f6

- [x] No issue about [NSDK-238] Inpage text for on-boarding user has 2 patterns at random

For a one-size item, if the user hasn't entered their body data, it displays "簡単サイズチェック".
if the user has entered the body data, it displays "あなたの体で\nサイズを簡単チェック"

https://github.com/user-attachments/assets/e1c70367-fc69-4d86-b214-1aec6882f863

- [x] [NSDK-241] Fixed Inpage shows different size from that VS widget shows
- [x] [NSDK-242] Body data tuning is not saved once closing the widget

https://github.com/user-attachments/assets/fecdcc8d-b041-4b44-b1d3-0681dd0fd50b

## ☑️ Checklist

- [x] Useless comments and/or `print` etc are **removed**
- [ ] Unit test are **covered**
- [ ] Code has been **deployed and tested** on STG
- [ ] ClickUp ticket status has been **updated** to `production`
- [x] Update CHANGELOG.md with the new changes
