### PR TITLE
Internal Logger

### DIFF
--- a/.github/workflows/pull-request-checks.yml
+++ b/.github/workflows/pull-request-checks.yml
@@ -39,6 +39,7 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v4
+      # This step should be removed after 6 Jan, 2025 when macos-latest updates XCode from 16.0 to 16.2
       - name: Latest XCode
         uses: maxim-lobanov/setup-xcode@v1
         with:

--- a/.github/workflows/pull-request-checks.yml
+++ b/.github/workflows/pull-request-checks.yml
@@ -39,6 +39,10 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v4
+      - name: Latest XCode
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: latest-stable
       - name: Run VirtusizeCoreTests
         run: make virtusize-core-test
       - name: Run VirtusizeTests

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,8 +13,11 @@ Use list notation, and following prefixes:
 
 ## NEXT RELEASE for Version 2.x.x
 
+### Next Release
+- Feature: Introduce internal logger (see [README/logger](/README.md#optional-confgiure-internal-logger) for configuration)
+
 ### 2.6.6
-- Fix:  Inpage text is not appropriate when the size is recommended
+- Fix: Inpage text is not appropriate when the size is recommended
 - Fix: Inpage text for on-boarding user has 2 patterns at random
 
 ### 2.6.5

--- a/Example/Sources/AppDelegate.swift
+++ b/Example/Sources/AppDelegate.swift
@@ -33,6 +33,14 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 	func application(
 		_ application: UIApplication,
 		didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+
+		// Setup Virtusize LogLevel
+		VirtusizeLogger.logLevel = .debug // `.none` is default
+		// Override Virtusize log handler, if necessary
+		//VirtusizeLogger.logHandler = { logLevel, message in
+		//	print("[Virtusize] \(logLevel): \(message)")
+		//}
+
 		// Virtusize.APIKey is required
 		Virtusize.APIKey = "15cc36e1d7dad62b8e11722ce1a245cb6c5e6692"
 		// For using the Order API, Virtusize.userID is required

--- a/README.md
+++ b/README.md
@@ -161,6 +161,25 @@ You can set up the `Virtusize.params` by using **VirtusizeParamsBuilder** to cha
 | setDetailsPanelCards | A list of `VirtusizeInfoCategory` | setDetailsPanelCards([VirtusizeInfoCategory.BRANDSIZING, VirtusizeInfoCategory.GENERALFIT]) | The info categories which will be displayed in the Product Details tab. Possible categories are: `VirtusizeInfoCategory.MODELINFO`, `VirtusizeInfoCategory.GENERALFIT`, `VirtusizeInfoCategory.BRANDSIZING` and `VirtusizeInfoCategory.MATERIAL` | No. By default, the integration displays all the possible info categories in the Product Details tab. |
 | setShowSNSButtons | Boolean | setShowSNSButtons(true)| Determines whether the integration will show SNS buttons | No. By default, ShowSNSButtons is set to false |
 
+#### (Optional) Confgiure Internal Logger
+
+You can enable internal logger for debugging purpose by updating App delegate:
+
+```Swift
+func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
+		// Setup Virtusize LogLevel
+		VirtusizeLogger.logLevel = .debug // `.none` is default
+		// Override Virtusize log handler, if necessary
+		//VirtusizeLogger.logHandler = { logLevel, message in
+		//	print("[Virtusize] \(logLevel): \(message)")
+		//}
+
+    // ... continue Virtusize and App initialization
+
+    return true
+}
+```
+
 ### 2. Load Product with Virtusize SDK
 
 In the view controller for your product page, you will need to use `Virtusize.load` to populate the Virtusize views:

--- a/VirtusizeCore/Sources/Utils/VirtusizeLogger.swift
+++ b/VirtusizeCore/Sources/Utils/VirtusizeLogger.swift
@@ -1,0 +1,59 @@
+//
+//  InternalLogger.swift
+//  VirtusizeCore
+//
+//  Copyright (c) 2024 Virtusize KK
+//
+
+public enum VirtusizeLogLevel: Int, CustomStringConvertible {
+	case none = 0
+	case error
+	case warning
+	case debug
+
+	public var description: String {
+		switch self {
+		case .none:
+			return "None"
+		case .error:
+			return "Error"
+		case .warning:
+			return "Warning"
+		case .debug:
+			return "Debug"
+		}
+	}
+}
+
+public class VirtusizeLogger {
+	public static var logLevel: VirtusizeLogLevel = .none
+	public static var logHandler: ((VirtusizeLogLevel, String) -> Void)?
+
+	public static func debug(_ message: String) {
+		log(level: .debug, message: message)
+	}
+
+	public static func warn(_ message: String) {
+		log(level: .warning, message: message)
+	}
+
+	public static func error(_ message: String) {
+		log(level: .error, message: message)
+	}
+
+	static func log(level: VirtusizeLogLevel, message: String) {
+		if level == VirtusizeLogLevel.none {
+			return
+		}
+		guard level.rawValue <= logLevel.rawValue else {
+			return
+		}
+
+		if let handler = logHandler {
+			handler(level, message)
+		} else {
+			let logMessage = "[Virtusize] \(level.description): \(message)"
+			print(logMessage)
+		}
+	}
+}

--- a/VirtusizeCore/Sources/Utils/VirtusizeLogger.swift
+++ b/VirtusizeCore/Sources/Utils/VirtusizeLogger.swift
@@ -4,6 +4,24 @@
 //
 //  Copyright (c) 2024 Virtusize KK
 //
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
 
 public enum VirtusizeLogLevel: Int, CustomStringConvertible {
 	case none = 0

--- a/VirtusizeCore/Tests/Utils/VirtusizeLoggerTests.swift
+++ b/VirtusizeCore/Tests/Utils/VirtusizeLoggerTests.swift
@@ -8,7 +8,7 @@
 import Testing
 @testable import VirtusizeCore
 
-struct VirtusizeAuthTests {
+struct VirtusizeLoggerTests {
 	@Test func logHandler() {
 		var invoked = false
 		VirtusizeLogger.logLevel = .debug

--- a/VirtusizeCore/Tests/Utils/VirtusizeLoggerTests.swift
+++ b/VirtusizeCore/Tests/Utils/VirtusizeLoggerTests.swift
@@ -4,6 +4,24 @@
 //
 //  Copyright (c) 2024 Virtusize KK
 //
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
 
 import Testing
 @testable import VirtusizeCore

--- a/VirtusizeCore/Tests/Utils/VirtusizeLoggerTests.swift
+++ b/VirtusizeCore/Tests/Utils/VirtusizeLoggerTests.swift
@@ -1,0 +1,33 @@
+//
+//  VirtusizeLoggerTests.swift
+//  VirtusizeCore
+//
+//  Copyright (c) 2024 Virtusize KK
+//
+
+import Testing
+@testable import VirtusizeCore
+
+struct VirtusizeAuthTests {
+	@Test func logHandler() {
+		var invoked = false
+		VirtusizeLogger.logLevel = .debug
+		VirtusizeLogger.logHandler = { logLevel, message in
+			#expect(logLevel == VirtusizeLogLevel.debug)
+			#expect(message == "hello")
+			invoked = true
+		}
+		VirtusizeLogger.debug("hello")
+		#expect(invoked == true)
+	}
+	
+	@Test func respectLevel() {
+		var invoked = false
+		VirtusizeLogger.logLevel = .warning
+		VirtusizeLogger.logHandler = { logLevel, message in
+			invoked = true
+		}
+		VirtusizeLogger.debug("hello")
+		#expect(invoked == false)
+	}
+}

--- a/VirtusizeCore/VirtusizeCore.xcodeproj/project.pbxproj
+++ b/VirtusizeCore/VirtusizeCore.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		523242472D1AC8AE00290069 /* VirtusizeLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 523242462D1AC89F00290069 /* VirtusizeLogger.swift */; };
+		5232424C2D1D93A100290069 /* VirtusizeLoggerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5232424B2D1D939B00290069 /* VirtusizeLoggerTests.swift */; };
 		84CF03B72BD7A2BA00C08920 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 84CF03B62BD7A2BA00C08920 /* PrivacyInfo.xcprivacy */; };
 		9C2B0D58273AB660004B10BB /* VirtusizeCore.podspec in Resources */ = {isa = PBXBuildFile; fileRef = 9C2B0D57273AB660004B10BB /* VirtusizeCore.podspec */; };
 		9C3505FD2727074A003BEF82 /* VirtusizeCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9C3505F32727074A003BEF82 /* VirtusizeCore.framework */; };
@@ -38,6 +40,8 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		523242462D1AC89F00290069 /* VirtusizeLogger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VirtusizeLogger.swift; sourceTree = "<group>"; };
+		5232424B2D1D939B00290069 /* VirtusizeLoggerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VirtusizeLoggerTests.swift; sourceTree = "<group>"; };
 		84CF03B62BD7A2BA00C08920 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		9C2B0D57273AB660004B10BB /* VirtusizeCore.podspec */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; fileEncoding = 4; name = VirtusizeCore.podspec; path = ../VirtusizeCore.podspec; sourceTree = "<group>"; };
 		9C3505F32727074A003BEF82 /* VirtusizeCore.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = VirtusizeCore.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -82,6 +86,14 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		5232424A2D1D938000290069 /* Utils */ = {
+			isa = PBXGroup;
+			children = (
+				5232424B2D1D939B00290069 /* VirtusizeLoggerTests.swift */,
+			);
+			path = Utils;
+			sourceTree = "<group>";
+		};
 		9C3505E92727074A003BEF82 = {
 			isa = PBXGroup;
 			children = (
@@ -118,6 +130,7 @@
 		9C3506002727074A003BEF82 /* Tests */ = {
 			isa = PBXGroup;
 			children = (
+				5232424A2D1D938000290069 /* Utils */,
 				9C6E36C42739615900608640 /* Workers */,
 				9C3506032727074A003BEF82 /* Info.plist */,
 			);
@@ -136,6 +149,7 @@
 		9C35061727278B7C003BEF82 /* Utils */ = {
 			isa = PBXGroup;
 			children = (
+				523242462D1AC89F00290069 /* VirtusizeLogger.swift */,
 				9C35067427280396003BEF82 /* HTTPURLResponse+Extensions.swift */,
 				9C35062C2727B781003BEF82 /* VirtusizeCoreBundleLoader.swift */,
 				9C35062D2727B781003BEF82 /* BundleLoaderProtocal.swift */,
@@ -342,6 +356,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				9C3506692727FF4B003BEF82 /* UserDefaultsHelper.swift in Sources */,
+				523242472D1AC8AE00290069 /* VirtusizeLogger.swift in Sources */,
 				9C35062F2727B782003BEF82 /* BundleLoaderProtocal.swift in Sources */,
 				9C35067527280396003BEF82 /* HTTPURLResponse+Extensions.swift in Sources */,
 				9CAD1F4C2CF4AB6E00AC104E /* APICache.swift in Sources */,
@@ -361,6 +376,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				9C6E36C72739616E00608640 /* UserDefaultsHelperTests.swift in Sources */,
+				5232424C2D1D93A100290069 /* VirtusizeLoggerTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/VirtusizeCore/VirtusizeCore.xcodeproj/project.pbxproj
+++ b/VirtusizeCore/VirtusizeCore.xcodeproj/project.pbxproj
@@ -9,6 +9,8 @@
 /* Begin PBXBuildFile section */
 		523242472D1AC8AE00290069 /* VirtusizeLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 523242462D1AC89F00290069 /* VirtusizeLogger.swift */; };
 		5232424C2D1D93A100290069 /* VirtusizeLoggerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5232424B2D1D939B00290069 /* VirtusizeLoggerTests.swift */; };
+		52EED1CF2D24034900A10359 /* Testing.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 52EED1CE2D24034900A10359 /* Testing.framework */; platformFilter = ios; };
+		52EED1D02D24034A00A10359 /* Testing.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 52EED1CE2D24034900A10359 /* Testing.framework */; platformFilter = ios; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		84CF03B72BD7A2BA00C08920 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 84CF03B62BD7A2BA00C08920 /* PrivacyInfo.xcprivacy */; };
 		9C2B0D58273AB660004B10BB /* VirtusizeCore.podspec in Resources */ = {isa = PBXBuildFile; fileRef = 9C2B0D57273AB660004B10BB /* VirtusizeCore.podspec */; };
 		9C3505FD2727074A003BEF82 /* VirtusizeCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9C3505F32727074A003BEF82 /* VirtusizeCore.framework */; };
@@ -39,9 +41,24 @@
 		};
 /* End PBXContainerItemProxy section */
 
+/* Begin PBXCopyFilesBuildPhase section */
+		52EED1D12D24034A00A10359 /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				52EED1D02D24034A00A10359 /* Testing.framework in Embed Frameworks */,
+			);
+			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
+
 /* Begin PBXFileReference section */
 		523242462D1AC89F00290069 /* VirtusizeLogger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VirtusizeLogger.swift; sourceTree = "<group>"; };
 		5232424B2D1D939B00290069 /* VirtusizeLoggerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VirtusizeLoggerTests.swift; sourceTree = "<group>"; };
+		52EED1CE2D24034900A10359 /* Testing.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Testing.framework; path = Platforms/iPhoneOS.platform/Developer/Library/Frameworks/Testing.framework; sourceTree = DEVELOPER_DIR; };
 		84CF03B62BD7A2BA00C08920 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		9C2B0D57273AB660004B10BB /* VirtusizeCore.podspec */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; fileEncoding = 4; name = VirtusizeCore.podspec; path = ../VirtusizeCore.podspec; sourceTree = "<group>"; };
 		9C3505F32727074A003BEF82 /* VirtusizeCore.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = VirtusizeCore.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -80,6 +97,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				9C3505FD2727074A003BEF82 /* VirtusizeCore.framework in Frameworks */,
+				52EED1CF2D24034900A10359 /* Testing.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -94,12 +112,21 @@
 			path = Utils;
 			sourceTree = "<group>";
 		};
+		52EED1CD2D24034900A10359 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				52EED1CE2D24034900A10359 /* Testing.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
 		9C3505E92727074A003BEF82 = {
 			isa = PBXGroup;
 			children = (
 				9C2B0D57273AB660004B10BB /* VirtusizeCore.podspec */,
 				9C3505F52727074A003BEF82 /* Sources */,
 				9C3506002727074A003BEF82 /* Tests */,
+				52EED1CD2D24034900A10359 /* Frameworks */,
 				9C3505F42727074A003BEF82 /* Products */,
 			);
 			sourceTree = "<group>";
@@ -259,6 +286,7 @@
 				9C3505F82727074A003BEF82 /* Sources */,
 				9C3505F92727074A003BEF82 /* Frameworks */,
 				9C3505FA2727074A003BEF82 /* Resources */,
+				52EED1D12D24034A00A10359 /* Embed Frameworks */,
 			);
 			buildRules = (
 			);


### PR DESCRIPTION
## 🔗 Related Links

- [x] https://github.com/virtusize/integration_ios/pull/139

## ⬅️ As Is

Explain the current situation of the code

- It's hard to debug Main and Auth libraries, as all the "debug" code should deleted before the release. It's important to occasionally turn on/off debugging code for inspection

## ➡️ To Be

- [x] Have an internal logger that can be used across Main/Core/Auth libraries to turn on/off debug/warning/error traces

## ☑️ Checklist

- [x] Useless comments and/or `print` etc are **removed**
- [x] Unit test are **covered**
- [ ] Code has been **deployed and tested** on STG
- [ ] ClickUp ticket status has been **updated** to `production`
- [x] Update CHANGELOG.md with the new changes
- [x] Update README.md to explain usage
- [x] Update Example to demonstrate setup or usage
