### PR TITLE
Validate fonts on push (PR and git-hooks)

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,8 +1,11 @@
 #!/bin/sh
 
+# Validate fonts
+echo "Validating fonts..."
+make validate-fonts # ensure the font subset supports all localization texts
+
 # Run tests
 echo "Running tests..."
-make validate-fonts # ensure the font subset supports all localization texts
 make test # linter is run as part of the tests build
 
 status=$?

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -2,6 +2,7 @@
 
 # Run tests
 echo "Running tests..."
+make validate-fonts # ensure the font subset supports all localization texts
 make test # linter is run as part of the tests build
 
 status=$?

--- a/.github/workflows/pull-request-checks.yml
+++ b/.github/workflows/pull-request-checks.yml
@@ -43,11 +43,6 @@ jobs:
         run: |
           pip install --upgrade fonttools
           make validate-fonts
-      # This step should be removed after 6 Jan, 2025 when macos-latest updates XCode from 16.0 to 16.2
-      - name: Latest XCode
-        uses: maxim-lobanov/setup-xcode@v1
-        with:
-          xcode-version: latest-stable
       - name: Run VirtusizeCoreTests
         run: make virtusize-core-test
       - name: Run VirtusizeTests

--- a/.github/workflows/pull-request-checks.yml
+++ b/.github/workflows/pull-request-checks.yml
@@ -35,7 +35,7 @@ jobs:
           command: pod lib lint Virtusize.podspec --allow-warnings
 
   test:
-    runs-on: macos-latest
+    runs-on: macos-15
     steps:
       - name: Check out code
         uses: actions/checkout@v4

--- a/.github/workflows/pull-request-checks.yml
+++ b/.github/workflows/pull-request-checks.yml
@@ -43,6 +43,11 @@ jobs:
         run: |
           pip install --upgrade fonttools
           make validate-fonts
+      # This step should be removed after 6 Jan, 2025 when macos-latest updates XCode from 16.0 to 16.2
+      - name: Latest XCode
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: latest-stable
       - name: Run VirtusizeCoreTests
         run: make virtusize-core-test
       - name: Run VirtusizeTests

--- a/.github/workflows/pull-request-checks.yml
+++ b/.github/workflows/pull-request-checks.yml
@@ -39,6 +39,10 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v4
+      - name: Validate Fonts
+        run: |
+          pip install --upgrade fonttools
+          make validate-fonts
       # This step should be removed after 6 Jan, 2025 when macos-latest updates XCode from 16.0 to 16.2
       - name: Latest XCode
         uses: maxim-lobanov/setup-xcode@v1

--- a/.github/workflows/pull-request-checks.yml
+++ b/.github/workflows/pull-request-checks.yml
@@ -48,6 +48,8 @@ jobs:
         uses: maxim-lobanov/setup-xcode@v1
         with:
           xcode-version: latest-stable
+      - name: Print Installed Simulators
+        run: xcrun simctl list
       - name: Run VirtusizeCoreTests
         run: make virtusize-core-test
       - name: Run VirtusizeTests

--- a/Makefile
+++ b/Makefile
@@ -59,6 +59,10 @@ validate-fonts:
 
 	sh ./Scripts/validate_fonts.sh
 
+build-fonts:
+
+	sh ./Scripts/build_fonts.sh
+
 install-git-hooks:
 
 	chmod +x .githooks/pre-push

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ build:
 		-workspace "Virtusize.xcworkspace" \
 		-scheme "Virtusize" \
 		-sdk "iphonesimulator" \
-		-destination "platform=iOS Simulator,name=iPhone SE (3rd generation),OS=latest"
+		-destination "platform=iOS Simulator,name=iPhone SE (3rd generation),OS=18.1"
 
 virtusize-test:
 

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ build:
 		-workspace "Virtusize.xcworkspace" \
 		-scheme "Virtusize" \
 		-sdk "iphonesimulator" \
-		-destination "platform=iOS Simulator,name=iPhone SE (3rd generation),OS=latest"
+		-destination "platform=iOS Simulator,name=iPhone SE (3rd generation),OS=18.1"
 
 virtusize-test:
 
@@ -30,7 +30,7 @@ virtusize-test:
 		-workspace "Virtusize.xcworkspace" \
 		-scheme "VirtusizeTests" \
 		-sdk "iphonesimulator" \
-		-destination "platform=iOS Simulator,name=iPhone SE (3rd generation),OS=latest"
+		-destination "platform=iOS Simulator,name=iPhone SE (3rd generation),OS=18.1"
 
 virtusize-core-test:
 

--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,10 @@ lint-fix:
 
 	swiftlint --fix --strict
 
+validate-fonts:
+
+	sh ./Scripts/validate_fonts.sh
+
 install-git-hooks:
 
 	chmod +x .githooks/pre-push

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ build:
 		-workspace "Virtusize.xcworkspace" \
 		-scheme "Virtusize" \
 		-sdk "iphonesimulator" \
-		-destination "platform=iOS Simulator,name=iPhone SE (3rd generation),OS=18.1"
+		-destination "platform=iOS Simulator,name=iPhone SE (3rd generation),OS=latest"
 
 virtusize-test:
 
@@ -39,7 +39,7 @@ virtusize-core-test:
 		-workspace "Virtusize.xcworkspace" \
 		-scheme "VirtusizeCoreTests" \
 		-sdk "iphonesimulator" \
-		-destination "platform=iOS Simulator,name=iPhone SE (3rd generation),OS=latest"
+		-destination "platform=iOS Simulator,name=iPhone SE (3rd generation),OS=18.1"
 
 test: virtusize-test virtusize-core-test
 

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ build:
 		-workspace "Virtusize.xcworkspace" \
 		-scheme "Virtusize" \
 		-sdk "iphonesimulator" \
-		-destination "platform=iOS Simulator,name=iPhone SE (3rd generation),OS=18.1"
+		-destination "platform=iOS Simulator,name=iPhone SE (3rd generation),OS=latest"
 
 virtusize-test:
 
@@ -30,7 +30,7 @@ virtusize-test:
 		-workspace "Virtusize.xcworkspace" \
 		-scheme "VirtusizeTests" \
 		-sdk "iphonesimulator" \
-		-destination "platform=iOS Simulator,name=iPhone SE (3rd generation),OS=18.1"
+		-destination "platform=iOS Simulator,name=iPhone SE (3rd generation),OS=latest"
 
 virtusize-core-test:
 
@@ -39,7 +39,7 @@ virtusize-core-test:
 		-workspace "Virtusize.xcworkspace" \
 		-scheme "VirtusizeCoreTests" \
 		-sdk "iphonesimulator" \
-		-destination "platform=iOS Simulator,name=iPhone SE (3rd generation),OS=18.1"
+		-destination "platform=iOS Simulator,name=iPhone SE (3rd generation),OS=latest"
 
 test: virtusize-test virtusize-core-test
 

--- a/Scripts/build_fonts.sh
+++ b/Scripts/build_fonts.sh
@@ -18,14 +18,14 @@ rename_font() {
   local new_name="Subset-$font_name"
 
   # Extract TTX XML
-  ttx "$font_dir/$font"
+  ttx -q "$font_dir/$font"
   local ttx_file="$font_dir/$font_name.ttx"
 
   # Rename Font inside the TTX file
   sed -i '' "s/$font_name/$new_name/g" "$ttx_file"
 
   # Re-generate font
-  ttx -o "$font_dir/$new_name.ttf" "$ttx_file"
+  ttx -q -o "$font_dir/$new_name.ttf" "$ttx_file"
 
   # Clean up TTX file
   rm "$ttx_file"
@@ -42,6 +42,8 @@ rename_font() {
 generate_subset_font() {
   local font="$1"
   local language="$2"
+
+  echo "Processing '$font' ..."
 
   # create subset font
   pyftsubset ${SOURCE_FONT_DIR}/${font} \

--- a/Scripts/validate_fonts.sh
+++ b/Scripts/validate_fonts.sh
@@ -1,0 +1,94 @@
+#!/bin/bash
+
+FONTS_DIR=./Virtusize/Sources/Resources/Fonts
+LOCALIZATION_DIR=./VirtusizeCore/Sources/Resources/Localizations
+
+# Strategy:
+#   1. Fetch all the glyphs from the font file
+#   2. Prepare a list of unique unicode characters supported by font
+#   3. Prepare a list of unique unicode characters used in localisation file
+#   4. Compare lists
+#
+# Note:
+#   Unfortuntely, old bash version doesn't support a feature 
+#   when `echo '\ub6c7'` converts encoded symbol into actual character.
+#   If it would, we could simply convert TTX unicodes into characters and
+#   compare with localization files.
+#
+#   Instead, to ensure the script runs everywhere, we convert both - localization characters
+#   and font subset glyphs into UTF-32 format: \U0000aaaa
+#   And match those. Which works.
+validate_font_symbols() {
+    local font_file=$1
+    local text_file=$2
+    local tmp_dir=./.build/tmp/font
+
+    # Make TMP directory to save intermidiate files
+    mkdir -p $tmp_dir
+
+    # Prepare the unicode lists from both, localization file and font subset
+    {
+        # Extract Font metadata
+        ttx -q -t cmap -o $tmp_dir/font.ttx $font_file
+
+        # Prepare Expected characters
+        grep -o . $text_file | sort | uniq > $tmp_dir/text_chars.txt
+
+        # Convert Font glyphs into list of unicodes in a UTF-32 format: \U12345678
+        awk -F'"' '/<map code=/{print $2}' $tmp_dir/font.ttx | sort | uniq | while IFS= read -r code; do
+            hex="$(printf '%08x' "$((code))")"
+            echo "\\U$hex"
+        done > $tmp_dir/font_unicodes.txt
+
+        # Convert Text characters into list of unicodes in a UTF-32 format: \U12345678
+        while IFS= read -r char; do
+            hex="$(printf "$char" | iconv -f UTF-8 -t UTF-32BE | xxd -p)"
+            echo "\\U$hex"
+        done < $tmp_dir/text_chars.txt | tee > $tmp_dir/text_unicodes.txt
+    }
+
+    # Validate all the necessary Unicode characters are preset in the font subset
+    {
+        local missing=0
+
+        # Check if each Unicode in text_unicodes.txt is present in the font_unicodes.txt
+        while IFS= read -r unicode; do
+            if ! grep -q "$unicode" $tmp_dir/font_unicodes.txt; then
+                echo "Missing character: $unicode"
+                missing=1
+            fi
+        done < $tmp_dir/text_unicodes.txt
+
+        # Output the result
+        if [ $missing -eq 0 ]; then
+            echo "SUCCESS: Localization texts are fully supported by the font '$(basename "$font_file")'."
+        else
+            echo "ERROR: Localization file '$text_file' is NOT fully supported by the font '$(basename "$font_file")'. See missing characters above."
+            exit 1
+        fi    
+    }
+
+    # Clean up tmp directory
+    rm -r $tmp_dir
+}
+
+# Wrapper function 
+validate_font() {
+  local font=$1
+  local language=$2
+
+  validate_font_symbols "$FONTS_DIR/$font" "$LOCALIZATION_DIR/$language.lproj/VirtusizeLocalizable.strings"
+}
+
+
+# Japanese Regular
+validate_font Subset-NotoSansJP-Regular.ttf ja
+
+# Japanese Bold
+validate_font Subset-NotoSansJP-Bold.ttf ja
+
+# Korean Regular
+validate_font Subset-NotoSansKR-Regular.ttf ko
+
+# Korean Bold
+validate_font Subset-NotoSansKR-Bold.ttf ko


### PR DESCRIPTION
We've discussed a way to re-build the fonts automatically.  
There are two downsides:
1. There should be a new commit to ensure created fonts are available from repository
2. If there are no changes to the localisation - the fonts are recreated anyway which make unnecessary grow of the repository size

Still, to achieve the goal and ensure the fonts are valid, a new script introduced to check if the existing font subset supports all the characters from the corresponding localization files.

## ⬅️ As Is

- Currently if the localisation modified, there is no guarantee the new characters are supported by the previously created fonts

## ➡️ To Be

- [x] Script to validate if all localisation characters are supported by the font
- [x] Added validation to `pre-push` git-hook 
- [x] Added validation step to `Makefile`
- [x] Invoked validation during the PR check

## ☑️ Checklist

- [x] Useless comments and/or `print` etc are **removed**
- [x] Tested locally for both scenarios (characters missing and all good)
- [ ] Update CHANGELOG.md with the new changes
