### PR TITLE
Fix SPM reference

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,10 +13,13 @@ Use list notation, and following prefixes:
 
 ## NEXT RELEASE for Version 2.x.x
 
+### Next Release
+- Fix: Compilation error when packages added via Swift Package Manager, due to missing explicit `import Foundation`
+
 ### 2.8.0
- - Refactor: Update SNS auth flow to fix an issue when users never returned back to the app after successful authentication
- - Refactor: Move in `VirtusizeAuth` source code into the main repository
- - Deprecate: `VirtusizeAuthentication.setAppBundleId` method is deprecated and removed, `bundleId` is resolved authomatically now.
+- Refactor: Update SNS auth flow to fix an issue when users never returned back to the app after successful authentication
+- Refactor: Move in `VirtusizeAuth` source code into the main repository
+- Deprecate: `VirtusizeAuthentication.setAppBundleId` method is deprecated and removed, `bundleId` is resolved authomatically now.
 
 ### 2.7.0
 - Feature: Introduce internal logger (see [README/logger](/README.md#optional-confgiure-internal-logger) for configuration)

--- a/VirtusizeAuth/Sources/API/FacebookAPIRequest.swift
+++ b/VirtusizeAuth/Sources/API/FacebookAPIRequest.swift
@@ -23,6 +23,7 @@
 //  THE SOFTWARE.
 //
 
+import Foundation
 import VirtusizeCore
 
 extension APIRequest {

--- a/VirtusizeAuth/Sources/API/GoogleAPIRequest.swift
+++ b/VirtusizeAuth/Sources/API/GoogleAPIRequest.swift
@@ -23,6 +23,7 @@
 //  THE SOFTWARE.
 //
 
+import Foundation
 import VirtusizeCore
 
 extension APIRequest {


### PR DESCRIPTION
## 🔗 Related Links

- [x] [ClickUp](https://app.clickup.com/t/3702259/NSDK-225)

## ⬅️ As Is

- Important `VirtusizeAuth` via Swift Package Manager leads to compilation error, due to missing `import Foundation`

## ➡️ To Be

- [x] Add explicit `import Foundation`

## ☑️ Checklist

- [x] Useless comments and/or `print` etc are **removed**
- [ ] Unit test are **covered**
- [ ] Code has been **deployed and tested** on STG
- [ ] ClickUp ticket status has been **updated** to `production`
- [x] Update CHANGELOG.md with the new changes
