### PR TITLE
Fix pods release flow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,35 +18,23 @@ jobs:
       - name: Install Cocoapods
         run: gem install cocoapods
 
-      - name: Pod Validation for VirtusizeCore
+      - name: Validate All Pods Locally
         run: |
           set -e -o pipefail
-          pod lib lint VirtusizeCore.podspec --allow-warnings
-          pod spec lint VirtusizeCore.podspec --allow-warnings
+          pod lib lint --include-podspecs="Virtusize*.podspec" --allow-warnings
 
+      # `pod trunk push` automatically validates pod version compatability
+      # so there is no need for extra `pod spec lint` call
+      # see https://guides.cocoapods.org/making/getting-setup-with-trunk#deploying-a-library
       - name: Push VirtusizeCore to CocoaPods
         run: |
-          pod trunk push VirtusizeCore.podspec --allow-warnings
-          pod repo update
+          pod trunk push VirtusizeCore.podspec --allow-warnings --synchronous
 
-      - name: Pod Validation for VirtusizeAuth
-        run: |
-          set -e -o pipefail
-          pod lib lint VirtusizeAuth.podspec --allow-warnings
-          pod spec lint VirtusizeAuth.podspec --allow-warnings
-
+      # --synchronous flag ensure the local repo is updated to lint and verify dependant packages
       - name: Push VirtusizeAuth to CocoaPods
         run: |
-          pod trunk push VirtusizeAuth.podspec --allow-warnings
-          pod repo update
-
-      - name: Pod Validation for Virtusize
-        run: |
-          set -e -o pipefail
-          pod lib lint Virtusize.podspec --allow-warnings
-          pod spec lint Virtusize.podspec --allow-warnings
+          pod trunk push VirtusizeAuth.podspec --allow-warnings --synchronous
 
       - name: Push Virtusize to CocoaPods
         run: |
-          pod trunk push Virtusize.podspec --allow-warnings
-          pod repo update
+          pod trunk push Virtusize.podspec --allow-warnings --synchronous

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,10 +13,13 @@ Use list notation, and following prefixes:
 
 ## NEXT RELEASE for Version 2.x.x
 
+### Next Release
+- Fix: Release pods synchronously
+
 ### 2.8.0
- - Refactor: Update SNS auth flow to fix an issue when users never returned back to the app after successful authentication
- - Refactor: Move in `VirtusizeAuth` source code into the main repository
- - Deprecate: `VirtusizeAuthentication.setAppBundleId` method is deprecated and removed, `bundleId` is resolved authomatically now.
+- Refactor: Update SNS auth flow to fix an issue when users never returned back to the app after successful authentication
+- Refactor: Move in `VirtusizeAuth` source code into the main repository
+- Deprecate: `VirtusizeAuthentication.setAppBundleId` method is deprecated and removed, `bundleId` is resolved authomatically now.
 
 ### 2.7.0
 - Feature: Introduce internal logger (see [README/logger](/README.md#optional-confgiure-internal-logger) for configuration)


### PR DESCRIPTION
## ⬅️ As Is

- Pods release fails, because local CocoaPods repository stays outdated (due to CDN nature)

## ➡️ To Be

- [x] Use specific flag `--syncronous` to release multiple dependant pods
- [x] Pods release flow works 

## ☑️ Checklist

- [x] Useless comments and/or `print` etc are **removed**
- [ ] Unit test are **covered**
- [ ] Code has been **deployed and tested** on STG
- [ ] ClickUp ticket status has been **updated** to `production`
- [x] Update CHANGELOG.md with the new changes
