### PR TITLE
Ensure SNS buttons are hidden when configured to do so

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,9 @@ Use list notation, and following prefixes:
 
 ## NEXT RELEASE for Version 2.x.x
 
+### Next Release
+- Fix: Ensure SNS buttons are hidden when configured to do so
+
 ### 2.8.1
 - Fix: Release pods synchronously
 - Fix: Compilation error when packages added via Swift Package Manager, due to missing explicit `import Foundation`

--- a/Virtusize/Sources/UI/VirtusizeWebViewController.swift
+++ b/Virtusize/Sources/UI/VirtusizeWebViewController.swift
@@ -168,8 +168,8 @@ extension VirtusizeWebViewController: WKNavigationDelegate, WKUIDelegate {
 			return
 		}
 		webView.evaluateJavaScript(vsParamsFromSDKScript, completionHandler: nil)
-        if let showSNSButtons = Virtusize.params?.showSNSButtons, showSNSButtons {
-            webView.evaluateJavaScript("window.virtusizeSNSEnabled = true;", completionHandler: nil)
+        if let showSNSButtons = Virtusize.params?.showSNSButtons {
+            webView.evaluateJavaScript("window.virtusizeSNSEnabled = \(showSNSButtons);", completionHandler: nil)
         }
 		checkAndUpdateBrowserID()
 	}


### PR DESCRIPTION
## ⬅️ As Is

- SNS still visible even thought `.setShowSNSButtons(false)` configured

## ➡️ To Be

- [x] Hide SNS buttons when `setShowSNSButtons(false)` applied

## ☑️ Checklist

- [x] Useless comments and/or `print` etc are **removed**
- [ ] Unit test are **covered**
- [ ] Code has been **deployed and tested** on STG
- [ ] ClickUp ticket status has been **updated** to `production`
- [x] Update CHANGELOG.md with the new changes
