### PR TITLE
Use cache-friendly endpoint to load product types

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,9 @@ Use list notation, and following prefixes:
 
 ## NEXT RELEASE for Version 2.x.x
 
+### Next Release
+- Fix: use cache-friendly endpoints for faster loading time
+
 ### 2.8.1
 - Fix: Release pods synchronously
 - Fix: Compilation error when packages added via Swift Package Manager, due to missing explicit `import Foundation`

--- a/Virtusize/Sources/Internal/API/APIEndpoints.swift
+++ b/Virtusize/Sources/Internal/API/APIEndpoints.swift
@@ -98,7 +98,8 @@ internal enum APIEndpoints {
 			components.queryItems = jsonFormatQueryItems()
 
 		case .productTypes:
-			components.path = "/a/api/v3/product-types"
+			let envPathForServicesAPI = Virtusize.environment.isProdEnv ? "" : "/stg"
+			components.path = "\(envPathForServicesAPI)/a/api/v3/product-types"
 
 		case .sessions:
 			components.path = "/a/api/v3/sessions"

--- a/Virtusize/Sources/Internal/API/APIEndpoints.swift
+++ b/Virtusize/Sources/Internal/API/APIEndpoints.swift
@@ -46,7 +46,7 @@ internal enum APIEndpoints {
     // MARK: - Properties
     var hostname: String {
 		switch self {
-		case .productCheck:
+		case .productCheck, .productTypes:
 			return Virtusize.environment.servicesUrl()
 		case  .getSize:
 			return Virtusize.environment.getSizeUrl()

--- a/Virtusize/Tests/APIEndpointsTests.swift
+++ b/Virtusize/Tests/APIEndpointsTests.swift
@@ -150,8 +150,8 @@ class APIEndpointsTests: XCTestCase {
     func testProductTypesEndpoint_returnExpectedComponents() {
         let endpoint = APIEndpoints.productTypes
 
-        XCTAssertEqual(endpoint.components.host, "staging.virtusize.com")
-        XCTAssertEqual(endpoint.components.path, "/a/api/v3/product-types")
+        XCTAssertEqual(endpoint.components.host, "services.virtusize.com")
+        XCTAssertEqual(endpoint.components.path, "/stg/a/api/v3/product-types")
 
         XCTAssertNil(endpoint.components.queryItems)
     }

--- a/Virtusize/Tests/APIRequestTests.swift
+++ b/Virtusize/Tests/APIRequestTests.swift
@@ -116,7 +116,7 @@ class APIRequestTests: XCTestCase {
         XCTAssertNil(apiRequest?.httpBody)
         XCTAssertEqual(
             apiRequest?.url?.absoluteString,
-            "https://staging.virtusize.com/a/api/v3/product-types"
+            "https://services.virtusize.com/stg/a/api/v3/product-types"
         )
     }
 


### PR DESCRIPTION
## ⬅️ As Is

- Product Types always loaded from the origin server, while it's data persistent and could be easily cached

## ➡️ To Be

- [x] Use cache friendly endpoint to load Product Types (as web app does)

## ☑️ Checklist

- [x] Useless comments and/or `print` etc are **removed**
- [x] Unit test are **covered**
- [ ] Code has been **deployed and tested** on STG
- [ ] ClickUp ticket status has been **updated** to `production`
- [x] Update CHANGELOG.md with the new changes
