### PR TITLE
Fix an issue when numeric size recommendations do not appear

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,6 +18,7 @@ Use list notation, and following prefixes:
 - Fix: Use cache-friendly endpoints for faster loading time
 - Fix: Ensure SNS buttons are hidden when configured to do so
 - Fix: Open Privacy Policy page when clicked
+- Fix: Numeric size recommendations now appear correct
 
 ### 2.8.1
 - Fix: Release pods synchronously

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,7 +18,7 @@ Use list notation, and following prefixes:
 - Fix: Use cache-friendly endpoints for faster loading time
 - Fix: Ensure SNS buttons are hidden when configured to do so
 - Fix: Open Privacy Policy page when clicked
-- Fix: Numeric size recommendations now appear correct
+- Fix: Numeric size recommendations now appear correctly
 
 ### 2.8.1
 - Fix: Release pods synchronously

--- a/Virtusize/Sources/Models/BodyProfileRecommendedSize.swift
+++ b/Virtusize/Sources/Models/BodyProfileRecommendedSize.swift
@@ -60,8 +60,8 @@ struct VirtualItem: Codable {
     let bust: Double?
     let waist: Double?
     let hip: Double?
-    let inseam: String?
-    let sleeve: String?
+    let inseam: Double?
+    let sleeve: Double?
 }
 
 // MARK: - WillFitForSizes

--- a/Virtusize/Tests/VirtusizeAPIServiceTests.swift
+++ b/Virtusize/Tests/VirtusizeAPIServiceTests.swift
@@ -22,6 +22,7 @@
 //  THE SOFTWARE.
 //
 
+import Foundation
 import XCTest
 @testable import Virtusize
 @testable import VirtusizeCore
@@ -671,6 +672,19 @@ class VirtusizeAPIServiceTests: XCTestCase {
         XCTAssertNotNil(actualRecommendedSizes)
         XCTAssertEqual(actualRecommendedSizes?.first?.sizeName, "35")
     }
+
+	func testGetUserBodyRecommendedSize_inseamAsNumber() throws {
+		let json =
+		// swiftlint:disable line_length
+"""
+[{"extProductId":"vs_pants","virtualItem":{"bust":null,"inseam":720.0,"sleeve":null}, "willFitForSizes":{"32":true,"31":true},"silhouetteGapLabels":null}]
+"""
+		// swiftlint:enable line_length
+		let data = json.data(using: .utf8)!
+		let result = try JSONDecoder().decode(BodyProfileRecommendedSizeArray.self, from: data)
+
+		XCTAssertEqual(result.first?.virtualItem?.inseam, 720)
+	}
 }
 
 extension VirtusizeAPIServiceTests {

--- a/VirtusizeCore/Sources/API/APIService.swift
+++ b/VirtusizeCore/Sources/API/APIService.swift
@@ -176,6 +176,7 @@ open class APIService {
 			let jsonString = String(data: data, encoding: String.Encoding.utf8)
 			return .success(result, jsonString)
 		} catch {
+			VirtusizeLogger.debug("Failed to parse JSON response: \(error)")
 			return .failure(apiResponse?.code, VirtusizeError.jsonDecodingFailed(String(describing: type), error))
 		}
 	}


### PR DESCRIPTION
## 🔗 Related Links

- [x] [ClickUp](https://app.clickup.com/t/3702259/NSDK-259)

## ⬅️ As Is

- Numeric size recommendations sometimes do not appear

## ➡️ To Be

- [x] Show numeric size recommendations

## ☑️ Checklist

- [x] Useless comments and/or `print` etc are **removed**
- [x] Unit test are **covered**
- [ ] Code has been **deployed and tested** on STG
- [ ] ClickUp ticket status has been **updated** to `production`
- [x] Update CHANGELOG.md with the new changes
