### PR TITLE
Fix local strings loading when using Pods

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,6 +21,7 @@ Use list notation, and following prefixes:
 - Fix: Open Privacy Policy page when clicked
 - Fix: Numeric size recommendations now appear correctly
 - Refactor: Remove iOS 11 code as current minimal version is 13
+- Fix: Fix localiztaion bundle name
 
 ### 2.8.1
 - Fix: Release pods synchronously

--- a/Virtusize/Sources/VirtusizeConfiguration.swift
+++ b/Virtusize/Sources/VirtusizeConfiguration.swift
@@ -27,5 +27,5 @@ import Foundation
 struct VirtusizeConfiguration {
 	static let SDKVersion = "2.8.1"
     static let defaultAoyamaVersion = "3.4.2"
-    static let resourceBundleName = "Virtusize_VirtusizeCore"
+    static let resourceBundleName = "VirtusizeCore"
 }


### PR DESCRIPTION
## ⬅️ As Is

- Local strings are not loaded when using Cocoapods (after pods refactoring in 2.8.x)

## ➡️ To Be

- [x] Local strings are properly loaded

## ☑️ Checklist

- [x] Useless comments and/or `print` etc are **removed**
- [ ] Unit test are **covered**
- [ ] Code has been **deployed and tested** on STG
- [ ] ClickUp ticket status has been **updated** to `production`
- [x] Update CHANGELOG.md with the new changes
