### PR TITLE
Add foundation imports

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,9 @@ Use list notation, and following prefixes:
 - Docs - for any improvement to documentation
 
 
+### 2.12.1
+- Fix: Add missing Foundation imports
+
 ### 2.12.0
 - Feature: Update Flutter SDK implementation to be compatible with latest changes
 

--- a/VirtusizeCore/Sources/Models/VirtusizeBranch.swift
+++ b/VirtusizeCore/Sources/Models/VirtusizeBranch.swift
@@ -23,6 +23,8 @@
 //  THE SOFTWARE.
 //
 
+import Foundation
+
 public class VirtusizeBranch {
 	/// Update `URL` with the `branch` name to test specific Virtusize environments
 	public static func applyBranch(to url: URL, branch: String) -> URL {

--- a/VirtusizeCore/Sources/Utils/ExpiringCache.swift
+++ b/VirtusizeCore/Sources/Utils/ExpiringCache.swift
@@ -23,6 +23,8 @@
 //  THE SOFTWARE.
 //
 
+import Foundation
+
 private enum CacheEntry {
 	case inProgress(Task<Any, Error>)
 	case ready(Date, Any)


### PR DESCRIPTION
## 🔗 Related Links

- [x] [ClickUp](https://app.clickup.com/t/3702259/NSDK-281)

## ⬅️ As Is

When adding Virtusize package with Swift Package manager XCode build fails with errors that several files miss the Foundation package import.

## ➡️ To Be

Foundation imports are added to files.

## ☑️ Checklist

- [x] Useless comments and/or `print` etc are **removed**
- [x] Unit test are **covered**
- [ ] Code has been **deployed and tested** on STG
- [ ] ClickUp ticket status has been **updated** to `production`
- [x] Update CHANGELOG.md with the new changes
