### PR TITLE
Align Virtusize button texts with Aoyama

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,7 @@ Use list notation, and following prefixes:
 
 ### Future release
 - Fix: Add loading animation for VirtusizeInPageViews
+- Fix: Change inpage buttons text to be the same as in web version
 
 ### 2.12.1
 - Fix: Add missing Foundation imports

--- a/VirtusizeCore/Sources/Resources/Localizations/en.lproj/VirtusizeLocalizable.strings
+++ b/VirtusizeCore/Sources/Resources/Localizations/en.lproj/VirtusizeLocalizable.strings
@@ -1,4 +1,4 @@
-"check_size" = "Check size";
+"check_size" = "Try it on";
 "privacy_policy" = "Privacy Policy";
 "privacy_policy_link" = "http://www.virtusize.com/site/privacy-policy";
 "inpage_default_accessory_text" = "See what fits inside";

--- a/VirtusizeCore/Sources/Resources/Localizations/ja.lproj/VirtusizeLocalizable.strings
+++ b/VirtusizeCore/Sources/Resources/Localizations/ja.lproj/VirtusizeLocalizable.strings
@@ -1,4 +1,4 @@
-"check_size" = "サイズチェック";
+"check_size" = "試着する";
 "privacy_policy" = "プライバシーポリシー";
 "privacy_policy_link" = "http://www.virtusize.jp/privacy-policy";
 "inpage_default_accessory_text" = "サイズ感を確認する";

--- a/VirtusizeCore/Sources/Resources/Localizations/ko.lproj/VirtusizeLocalizable.strings
+++ b/VirtusizeCore/Sources/Resources/Localizations/ko.lproj/VirtusizeLocalizable.strings
@@ -1,4 +1,4 @@
-"check_size" = "사이즈 확인";
+"check_size" = "입어보기";
 "privacy_policy" = "개인정보 처리방침";
 "privacy_policy_link" = "http://www.virtusize.kr/privacy-policy";
 "inpage_default_accessory_text" = "상품이 어울리는지 확인해보세요.";


### PR DESCRIPTION
## 🔗 Related Links

- [x] [ClickUp](https://app.clickup.com/t/3702259/NSDK-289)

## ⬅️ As Is

Virtusize SDK's inpage buttons text is not the same as in web version.

## ➡️ To Be

- [x] Virtusize SDK's inpage buttons text is the same as in web version.

## ☑️ Checklist

- [x] Useless comments and/or `print` etc are **removed**
- [x] Unit test are **covered**
- [ ] Code has been **deployed and tested** on STG
- [ ] ClickUp ticket status has been **updated** to `production`
- [x] Update CHANGELOG.md with the new changes
