### PR TITLE
Make sns buttons show by default

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,7 @@ Use list notation, and following prefixes:
 
 ### Future release
 - Fix: Add loading animation for VirtusizeInPageViews
+- Fix: Make sns buttons show by default
 
 ### 2.12.1
 - Fix: Add missing Foundation imports

--- a/README-JP.md
+++ b/README-JP.md
@@ -150,7 +150,7 @@ func application(_ application: UIApplication, didFinishLaunchingWithOptions lau
         // By default, Virtusize displays all the possible info categories in the Product Details tab,
         // including "modelInfo", "generalFit", "brandSizing" and "material".
         .setDetailsPanelCards([VirtusizeInfoCategory.BRANDSIZING, VirtusizeInfoCategory.GENERALFIT])
-        // By default, Virtusize disables the SNS buttons
+        // By default, Virtusize enables the SNS buttons
         .setShowSNSButtons(true)
         .build()
 
@@ -170,7 +170,7 @@ func application(_ application: UIApplication, didFinishLaunchingWithOptions lau
 | setShowSGI           | Boolean                             | setShowSGI(true)                                             | ユーザーが生成したアイテムをワードローブに追加する方法として、SGIを取得の上、SGIフローを使用するかどうかを決定します。 | 特になし。デフォルトではShowSGIはfalseに設定されています。   |
 | setAllowedLanguages  | `VirtusizeLanguage`列挙のリスト     | setAllowedLanguages([VirtusizeLanguage.ENGLISH, VirtusizeLanguage.JAPANESE]) | ユーザーが言語選択ボタンより選択できる言語                   | 特になし。デフォルトでは、英語、日本語、韓国語など、表示可能なすべての言語が表示されるようになっています。 |
 | setDetailsPanelCards | `VirtusizeInfoCategory`列挙のリスト | setDetailsPanelCards([VirtusizeInfoCategory.BRANDSIZING, VirtusizeInfoCategory.GENERALFIT]) | 商品詳細タブに表示する情報のカテゴリ。表示可能カテゴリは以下： `VirtusizeInfoCategory.MODELINFO`, `VirtusizeInfoCategory.GENERALFIT`, `VirtusizeInfoCategory.BRANDSIZING` および `VirtusizeInfoCategory.MATERIAL` | 特になし。デフォルトでは、商品詳細タブに表示可能なすべての情報カテゴリが表示されます。 |
-| setShowSNSButtons | Boolean | setShowSNSButtons(true)| Determines whether the integration will show SNS buttons | No. By default, ShowSNSButtons is set to false |
+| setShowSNSButtons | Boolean | setShowSNSButtons(true)| Determines whether the integration will show SNS buttons | No. By default, ShowSNSButtons is set to true |
 
 
 ### 2. Load Product with Virtusize SDK

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ func application(_ application: UIApplication, didFinishLaunchingWithOptions lau
         // By default, Virtusize displays all the possible info categories in the Product Details tab,
         // including "modelInfo", "generalFit", "brandSizing" and "material".
         .setDetailsPanelCards([VirtusizeInfoCategory.BRANDSIZING, VirtusizeInfoCategory.GENERALFIT])
-        // By default, Virtusize disables the SNS buttons
+        // By default, Virtusize enables the SNS buttons
         .setShowSNSButtons(true)
         // Target the specific environment branch by its name
         .setBranch("branch-name")
@@ -162,7 +162,7 @@ You can set up the `Virtusize.params` by using **VirtusizeParamsBuilder** to cha
 | setShowSGI | Boolean | setShowSGI(true) | Determines whether the integration will fetch SGI and use SGI flow for users to add user generated items to their wardrobe. | No. By default, ShowSGI is set to false |
 | setAllowedLanguages  | A list of `VirtusizeLanguage` | setAllowedLanguages([VirtusizeLanguage.ENGLISH, VirtusizeLanguage.JAPANESE]) | The languages that the user can switch to using the Language Selector | No. By default, the integration allows all the possible languages to be displayed, including English, Japanese and Korean. |
 | setDetailsPanelCards | A list of `VirtusizeInfoCategory` | setDetailsPanelCards([VirtusizeInfoCategory.BRANDSIZING, VirtusizeInfoCategory.GENERALFIT]) | The info categories which will be displayed in the Product Details tab. Possible categories are: `VirtusizeInfoCategory.MODELINFO`, `VirtusizeInfoCategory.GENERALFIT`, `VirtusizeInfoCategory.BRANDSIZING` and `VirtusizeInfoCategory.MATERIAL` | No. By default, the integration displays all the possible info categories in the Product Details tab. |
-| setShowSNSButtons | Boolean | setShowSNSButtons(true)| Determines whether the integration will show SNS buttons | No. By default, ShowSNSButtons is set to false |
+| setShowSNSButtons | Boolean | setShowSNSButtons(true)| Determines whether the integration will show SNS buttons | No. By default, ShowSNSButtons is set to true |
 | setBranch | String | setBranch("branch-name")| Targets specific environment branch | No. By default, production environment is targeted. `staging` - staging environment is targeted. `<branch-name>` a specific branch is targeted |
 
 

--- a/Virtusize/Sources/Models/VirtusizeParamsBuilder.swift
+++ b/Virtusize/Sources/Models/VirtusizeParamsBuilder.swift
@@ -30,7 +30,7 @@ public class VirtusizeParamsBuilder {
 	private var virtusizeProduct: VirtusizeProduct?
 	private var showSGI: Bool = false
 	private var detailsPanelCards: [VirtusizeInfoCategory] = VirtusizeInfoCategory.allCases
-    private var showSNSButtons: Bool = false
+    private var showSNSButtons: Bool = true
 	private var branch: String?
 
 	public init() {}


### PR DESCRIPTION
## 🔗 Related Links

- [x] [ClickUp](https://app.clickup.com/t/3702259/NSDK-290)

## ⬅️ As Is

Sns buttons are hidden by default and should be enabled by setting showSNSButtons: true in VirtusizeParamsBuilder.

## ➡️ To Be

- [x] Sns buttons are enabled by default

## ☑️ Checklist

- [x] Useless comments and/or `print` etc are **removed**
- [x] Unit test are **covered**
- [ ] Code has been **deployed and tested** on STG
- [ ] ClickUp ticket status has been **updated** to `production`
- [x] Update CHANGELOG.md with the new changes
