### PR TITLE
Align mobile SDK size recommendation API requests with web implementation

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,9 @@ Use list notation, and following prefixes:
 - Bugfix - when fixing any major bug
 - Docs - for any improvement to documentation
 
+### Future release
+- Fix: Align mobile SDK size recommendation API requests with web implementation
+
 ### 2.12.3
 - Fix: Display proper size recommendation text
 

--- a/Virtusize.xcodeproj/project.pbxproj
+++ b/Virtusize.xcodeproj/project.pbxproj
@@ -27,6 +27,7 @@
 		52FDA2882D3A5C8F007F5AC8 /* VirtusizeAuth.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 52FDA2872D3A5C8F007F5AC8 /* VirtusizeAuth.framework */; };
 		741DD0692DA3D06B007DF2C3 /* VirtusizeFlutter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 741DD0682DA3D06B007DF2C3 /* VirtusizeFlutter.swift */; };
 		741DD06D2DA42E63007DF2C3 /* VirtusizeFlutterProductEventHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 741DD06C2DA42E63007DF2C3 /* VirtusizeFlutterProductEventHandler.swift */; };
+		748DF81A2E3FF2A9002CA7FC /* VirtusizeGetSizeParamsShoe.swift in Sources */ = {isa = PBXBuildFile; fileRef = 748DF8192E3FF2A9002CA7FC /* VirtusizeGetSizeParamsShoe.swift */; };
 		74F8E3BE2E0D5B7A002CAE98 /* virtusize_loading.gif in Resources */ = {isa = PBXBuildFile; fileRef = 74F8E3BD2E0D5B7A002CAE98 /* virtusize_loading.gif */; };
 		74F8E3D02E0EA477002CAE98 /* UIImageViewExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74F8E3CF2E0EA473002CAE98 /* UIImageViewExtensions.swift */; };
 		8455FFD42B29A0C500019B1B /* VirtusizeGetSizeItemsParam.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8455FFD32B29A0C500019B1B /* VirtusizeGetSizeItemsParam.swift */; };
@@ -159,6 +160,7 @@
 		52FDA2872D3A5C8F007F5AC8 /* VirtusizeAuth.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = VirtusizeAuth.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		741DD0682DA3D06B007DF2C3 /* VirtusizeFlutter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VirtusizeFlutter.swift; sourceTree = "<group>"; };
 		741DD06C2DA42E63007DF2C3 /* VirtusizeFlutterProductEventHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VirtusizeFlutterProductEventHandler.swift; sourceTree = "<group>"; };
+		748DF8192E3FF2A9002CA7FC /* VirtusizeGetSizeParamsShoe.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VirtusizeGetSizeParamsShoe.swift; sourceTree = "<group>"; };
 		74F8E3BD2E0D5B7A002CAE98 /* virtusize_loading.gif */ = {isa = PBXFileReference; lastKnownFileType = image.gif; path = virtusize_loading.gif; sourceTree = "<group>"; };
 		74F8E3CF2E0EA473002CAE98 /* UIImageViewExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIImageViewExtensions.swift; sourceTree = "<group>"; };
 		8455FFD32B29A0C500019B1B /* VirtusizeGetSizeItemsParam.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VirtusizeGetSizeItemsParam.swift; sourceTree = "<group>"; };
@@ -525,6 +527,7 @@
 		9CEC8D88252AB8EE001CBDFB /* Models */ = {
 			isa = PBXGroup;
 			children = (
+				748DF8192E3FF2A9002CA7FC /* VirtusizeGetSizeParamsShoe.swift */,
 				9C5956CE2484F9F50014DF51 /* VirtusizeStore.swift */,
 				9C11691E2521DEB1006827B9 /* VirtusizeAnyCodable.swift */,
 				9C633F292493C7ED009C4392 /* VirtusizeProductImageMetaData.swift */,
@@ -828,6 +831,7 @@
 				52D1E0972D6D04F80073737B /* JSON+Exensions.swift in Sources */,
 				9CEAB7C924D9676200F969E1 /* VirtusizeServerProduct.swift in Sources */,
 				9CFF411325B98FA900B21D4E /* Observable.swift in Sources */,
+				748DF81A2E3FF2A9002CA7FC /* VirtusizeGetSizeParamsShoe.swift in Sources */,
 				9C58751E24EF7D5000352474 /* VirtusizeView.swift in Sources */,
 				9C84B3FD26C2566B00DDF434 /* VirtusizeViewEventProtocol.swift in Sources */,
 				9C4378D7253444F600E8729A /* UserSessionInfo.swift in Sources */,

--- a/Virtusize/Sources/Flutter/VirtusizeFlutter.swift
+++ b/Virtusize/Sources/Flutter/VirtusizeFlutter.swift
@@ -141,7 +141,7 @@ public class VirtusizeFlutter: Virtusize {
         let recommendationText = serverProduct.getRecommendationText(
             VirtusizeRepository.shared.i18nLocalization!,
             sizeRecData.sizeComparisonRecommendedSize,
-            sizeRecData.bodyProfileRecommendedSize?.sizeName,
+            sizeRecData.bodyProfileRecommendedSize?.getSizeName,
             VirtusizeI18nLocalization.TrimType.MULTIPLELINES
         )
         flutterHandler?.onSizeRecommendationData(

--- a/Virtusize/Sources/Internal/API/APIEndpoints.swift
+++ b/Virtusize/Sources/Internal/API/APIEndpoints.swift
@@ -41,6 +41,7 @@ internal enum APIEndpoints {
 	case userProducts
 	case userBodyMeasurements
 	case getSize
+    case getShoeSize
 	case i18n(langCode: String)
 	case storeI18n(storeName: String)
 
@@ -49,8 +50,10 @@ internal enum APIEndpoints {
 		switch self {
 		case .productCheck, .productTypes, .storeProducts:
 			return Virtusize.environment.servicesUrl()
-		case  .getSize:
+		case .getSize:
 			return Virtusize.environment.getSizeUrl()
+        case .getShoeSize:
+            return Virtusize.environment.getSizeUrl()
 		case .latestAoyamaVersion, .virtusizeWebView, .virtusizeWebViewForSpecificClients:
 			return Virtusize.environment.virtusizeStaticApiUrl()
 		case .i18n:
@@ -133,6 +136,9 @@ internal enum APIEndpoints {
 
 		case .getSize:
 			components.path =  "/item"
+
+		case .getShoeSize:
+			components.path =  "/shoe"
 
 		case .i18n(let langCode):
 			components.path = "/bundle-payloads/aoyama/\(langCode)"

--- a/Virtusize/Sources/Internal/API/VirtusizeAPIRequest.swift
+++ b/Virtusize/Sources/Internal/API/VirtusizeAPIRequest.swift
@@ -185,17 +185,60 @@ extension APIRequest {
 		userBodyProfile: VirtusizeUserBodyProfile
 	) -> URLRequest? {
 		let endpoint = APIEndpoints.getSize
-		guard let jsonData = try? JSONEncoder().encode(
-			VirtusizeGetSizeParams(
-				productTypes: productTypes,
-				storeProduct: storeProduct,
-				userBodyProfile: userBodyProfile
-			)
+		let codable = VirtusizeGetSizeParams(
+			productTypes: productTypes,
+			storeProduct: storeProduct,
+			userBodyProfile: userBodyProfile
+		)
+		
+		let encoder = JSONEncoder()
+		encoder.keyEncodingStrategy = .convertToSnakeCase
+		guard let jsonData = try? encoder.encode(
+		    codable
 		) else {
-			return nil
+		    return nil
 		}
+        
+        // Convert jsonData to String for debugging
+        if let jsonString = String(data: jsonData, encoding: .utf8) {
+            print("getBodyProfileRecommendedSize payload: \(jsonString)")
+        }
 		return apiRequest(components: endpoint.components, withPayload: jsonData)
 	}
+    
+    /// Gets the `URLRequest` for the `getSizeShoe` request
+    ///
+    /// - Parameters:
+    ///   - productTypes: The list of available `ProductType`s
+    ///   - storeProduct: The store product info whose data type is `VirtusizeServerProduct`
+    ///   - userBodyProfile: The user body profile whose data type is  `VirtusizeUserBodyProfile`
+    /// - Returns: A `URLRequest` for the `getShoeSize` request
+    internal static func getBodyProfileRecommendedShoeSize(
+        productTypes: [VirtusizeProductType],
+        storeProduct: VirtusizeServerProduct,
+        userBodyProfile: VirtusizeUserBodyProfile
+    ) -> URLRequest? {
+        let endpoint = APIEndpoints.getShoeSize
+        let codable = VirtusizeGetSizeParamsShoe(
+            productTypes: productTypes,
+            storeProduct: storeProduct,
+            userBodyProfile: userBodyProfile
+        )
+        
+        let encoder = JSONEncoder()
+        encoder.keyEncodingStrategy = .convertToSnakeCase
+        guard let jsonData = try? encoder.encode(
+            codable
+        ) else {
+            return nil
+        }
+        
+        // Convert jsonData to String for debugging
+        if let jsonString = String(data: jsonData, encoding: .utf8) {
+            print("getBodyProfileRecommendedSize payload: \(jsonString)")
+        }
+        return apiRequest(components: endpoint.components, withPayload: jsonData)
+    }
 
 	/// Gets the `URLRequest` for the request to get i18n texts
 	///

--- a/Virtusize/Sources/Internal/API/VirtusizeAPIService.swift
+++ b/Virtusize/Sources/Internal/API/VirtusizeAPIService.swift
@@ -165,14 +165,14 @@ class VirtusizeAPIService: APIService {
 		return await getAPIResultAsync(request: request, type: VirtusizeUserBodyProfile.self)
 	}
 
-	/// The API request for retrieving the recommended sizes based on the user body profile
+	/// The API request for retrieving the recommended item sizes based on the user body profile
 	///
 	/// - Parameters:
 	///   - productTypes: A list of product types
 	///   - storeProduct: The store product data
 	///   - userBodyProfile: the user body profile data
-	/// - Returns: the user body profile recommended size array in the type of `BodyProfileRecommendedSize`
-	internal static func getBodyProfileRecommendedSizesAsync(
+	/// - Returns: the user body profile recommended item size array in the type of `BodyProfileRecommendedSize`
+	internal static func getBodyProfileRecommendedItemSizesAsync(
 		productTypes: [VirtusizeProductType],
 		storeProduct: VirtusizeServerProduct,
 		userBodyProfile: VirtusizeUserBodyProfile
@@ -186,6 +186,29 @@ class VirtusizeAPIService: APIService {
 		}
 
 		return await getAPIResultAsync(request: request, type: BodyProfileRecommendedSizeArray.self)
+	}
+
+	/// The API request for retrieving the recommended shoe size based on the user body profile
+	///
+	/// - Parameters:
+	///   - productTypes: A list of product types
+	///   - storeProduct: The store product data
+	///   - userBodyProfile: the user body profile data
+	/// - Returns: the user body profile recommended shoe size in the type of `BodyProfileRecommendedSize`
+	internal static func getBodyProfileRecommendedShoeSizeAsync(
+		productTypes: [VirtusizeProductType],
+		storeProduct: VirtusizeServerProduct,
+		userBodyProfile: VirtusizeUserBodyProfile
+	) async -> APIResult<BodyProfileRecommendedSize> {
+		guard let request = APIRequest.getBodyProfileRecommendedShoeSize(
+				productTypes: productTypes,
+				storeProduct: storeProduct,
+				userBodyProfile: userBodyProfile)
+        else {
+			return .failure(nil)
+		}
+
+		return await getAPIResultAsync(request: request, type: BodyProfileRecommendedSize.self)
 	}
 
 	/// The API request for getting i18n localization texts

--- a/Virtusize/Sources/Internal/Models/VirtusizeGetSizeParamsShoe.swift
+++ b/Virtusize/Sources/Internal/Models/VirtusizeGetSizeParamsShoe.swift
@@ -1,5 +1,5 @@
 //
-//  VirtusizeGetSizeParams.swift
+//  VirtusizeGetSizeParamsShoe.swift
 //
 //  Copyright (c) 2020 Virtusize KK
 //
@@ -24,8 +24,7 @@
 
 // swiftlint:disable:next line_length
 /// The structure that wraps the parameters for the API request to get the recommended size based on a user's body profile
-internal struct VirtusizeGetSizeParams: Codable {
-    var appOrigin: Int = 2
+internal struct VirtusizeGetSizeParamsShoe: Codable {
     /// The user body data
     var bodyData: [String: [String: VirtusizeAnyCodable]] = [:]
     /// The user's gender
@@ -36,10 +35,20 @@ internal struct VirtusizeGetSizeParams: Codable {
     var userWeight: Float?
     /// The user's age
     var userAge: Int?
-    /// The user's items
-    var items: [VirtusizeGetSizeItemsParam]
+    /// The product name
+    var productName: String = ""
+    /// The additional information about the product
+    var additionalInfo: [String: VirtusizeAnyCodable] = [:]
+    /// The item sizes
+    var itemSizesOrig: [String: [String: Int?]] = [:]
+    /// The product type
+    var productType: String
+    /// The external product ID
+    var extProductId: String
+    
+    var footwearData: [String: VirtusizeAnyCodable] = [:]
 
-    /// Initializes the VirtusizeGetSizeParams structure
+    /// Initializes the VirtusizeGetSizeParamsShoe structure
     ///
     /// - Parameters:
     ///   - productTypes: The list of available `VirtusizeProductType`
@@ -51,7 +60,7 @@ internal struct VirtusizeGetSizeParams: Codable {
         userBodyProfile: VirtusizeUserBodyProfile?
 
     ) {
-       let additionalInfo = [
+        additionalInfo = [
             "brand": VirtusizeAnyCodable(
                 storeProduct.storeProductMeta?.additionalInfo?.brand ?? storeProduct.storeProductMeta?.brand ?? ""
             ),
@@ -70,8 +79,10 @@ internal struct VirtusizeGetSizeParams: Codable {
             ),
         ]
         bodyData = getBodyDataDict(userBodyProfile: userBodyProfile)
-        let itemSizesOrig = getItemSizesDict(storeProduct: storeProduct)
-        var productType = ""
+        itemSizesOrig = getItemSizesDict(storeProduct: storeProduct)
+        productType = ""
+        extProductId = storeProduct.externalId
+
         if let index = productTypes.firstIndex(where: { $0.id == storeProduct.productType }) {
             productType = productTypes[index].name
         }
@@ -81,16 +92,8 @@ internal struct VirtusizeGetSizeParams: Codable {
             userWeight = Float(weight)
         }
         userAge = userBodyProfile?.age
-
-        items = [
-            VirtusizeGetSizeItemsParam(
-                additionalInfo: additionalInfo,
-                itemSizesOrig: itemSizesOrig,
-                productType: productType,
-                extProductId: storeProduct.externalId
-            )
-        ]
-
+        productName = storeProduct.name
+        footwearData = userBodyProfile?.footwearData ?? [:]
     }
 }
 

--- a/Virtusize/Sources/Models/BodyProfileRecommendedSize.swift
+++ b/Virtusize/Sources/Models/BodyProfileRecommendedSize.swift
@@ -27,6 +27,7 @@
 public struct BodyProfileRecommendedSize: Codable {
     let extProductId: String?
     let sizeName: String?
+    let size: String?
     let secondSize: String?
     let fitScore: Double?
     let secondFitScore: Double?
@@ -37,9 +38,10 @@ public struct BodyProfileRecommendedSize: Codable {
     let scenario: String?
     let willFitForSizes: WillFitForSizes?
     // swiftlint:disable line_length
-    init(extProductId: String? = nil, sizeName: String, secondSize: String? = nil, fitScore: Double? = nil, secondFitScore: Double? = nil, fitScoreDifference: Double? = nil, virtualItem: VirtualItem? = nil, willFit: Bool? = nil, thresholdFitScore: Double? = nil, scenario: String? = nil, willFitForSizes: WillFitForSizes? = nil ) {
+    init(extProductId: String? = nil, sizeName: String, size: String = "", secondSize: String? = nil, fitScore: Double? = nil, secondFitScore: Double? = nil, fitScoreDifference: Double? = nil, virtualItem: VirtualItem? = nil, willFit: Bool? = nil, thresholdFitScore: Double? = nil, scenario: String? = nil, willFitForSizes: WillFitForSizes? = nil ) {
         self.extProductId = extProductId
         self.sizeName = sizeName
+        self.size = size
         self.secondSize = secondSize
         self.fitScore = fitScore
         self.secondFitScore = secondFitScore
@@ -51,6 +53,16 @@ public struct BodyProfileRecommendedSize: Codable {
         self.willFitForSizes = willFitForSizes
     }
     // swiftlint:enable line_length
+
+    public var getSizeName: String? {
+        if let sn = sizeName, !sn.isEmpty {
+            return sn
+        }
+        if let s = size, !s.isEmpty {
+            return s.replacingOccurrences(of: "&#46;", with: ".")
+        }
+        return ""
+    }
 }
 
 public typealias BodyProfileRecommendedSizeArray = [BodyProfileRecommendedSize]

--- a/Virtusize/Sources/Models/VirtusizeServerProduct.swift
+++ b/Virtusize/Sources/Models/VirtusizeServerProduct.swift
@@ -178,6 +178,11 @@ public class VirtusizeServerProduct: Codable {
 		return productType == 18 || productType == 19 || productType == 25 || productType == 26
 	}
 
+	/// Checks if the product is a shoe
+    internal func isShoe() -> Bool {
+		return productType == 17
+	}
+
 	/// Gets the Cloudinary image URL
 	internal func getCloudinaryImageUrl() -> URL? {
 		guard let imageUrlString = cloudinaryImageUrlString else {

--- a/Virtusize/Sources/Models/VirtusizeUserBodyProfile.swift
+++ b/Virtusize/Sources/Models/VirtusizeUserBodyProfile.swift
@@ -34,4 +34,6 @@ public class VirtusizeUserBodyProfile: Codable {
 	let weight: String?
 	/// The user's body measurement data, such as hip, bust, waist and so on.
 	let bodyData: [String: Int?]?
+	/// The user's footwear data, such as shoe size and width
+    let footwearData: [String: VirtusizeAnyCodable]?
 }

--- a/Virtusize/Sources/UI/VirtusizeInPageMini.swift
+++ b/Virtusize/Sources/UI/VirtusizeInPageMini.swift
@@ -81,7 +81,7 @@ public class VirtusizeInPageMini: VirtusizeInPageView {
 					sizeRecData.serverProduct.getRecommendationText(
 						VirtusizeRepository.shared.i18nLocalization!,
 						sizeRecData.sizeComparisonRecommendedSize,
-						sizeRecData.bodyProfileRecommendedSize?.sizeName,
+						sizeRecData.bodyProfileRecommendedSize?.getSizeName,
 						VirtusizeI18nLocalization.TrimType.ONELINE
 					)
 			).lineSpacing(self.verticalMargin/2)

--- a/Virtusize/Sources/UI/VirtusizeInPageStandard.swift
+++ b/Virtusize/Sources/UI/VirtusizeInPageStandard.swift
@@ -550,7 +550,7 @@ public class VirtusizeInPageStandard: VirtusizeInPageView { // swiftlint:disable
 		let recommendationText = serverProduct!.getRecommendationText(
 			VirtusizeRepository.shared.i18nLocalization!,
 			sizeComparisonRecommendedSize,
-			bodyProfileRecommendedSize?.sizeName,
+			bodyProfileRecommendedSize?.getSizeName,
 			trimType
 		)
 		let recommendationTextArray = recommendationText.components(separatedBy: trimType.rawValue)

--- a/Virtusize/Sources/VirtusizeRepository.swift
+++ b/Virtusize/Sources/VirtusizeRepository.swift
@@ -205,8 +205,7 @@ internal class VirtusizeRepository: NSObject { // swiftlint:disable:this type_bo
 		}
 
 		if let userBodyProfile = userBodyProfile {
-            if storeProduct.productType == 17 {
-				// If the product type is 17, we need to fetch the shoe size recommendations
+            if storeProduct.isShoe() {
 				bodyProfileRecommendedSize = await VirtusizeAPIService.getBodyProfileRecommendedShoeSizeAsync(
 					productTypes: productTypes!,
 					storeProduct: storeProduct,

--- a/Virtusize/Sources/VirtusizeRepository.swift
+++ b/Virtusize/Sources/VirtusizeRepository.swift
@@ -205,11 +205,20 @@ internal class VirtusizeRepository: NSObject { // swiftlint:disable:this type_bo
 		}
 
 		if let userBodyProfile = userBodyProfile {
-            bodyProfileRecommendedSize = await VirtusizeAPIService.getBodyProfileRecommendedSizesAsync(
-				productTypes: productTypes!,
-				storeProduct: storeProduct,
-				userBodyProfile: userBodyProfile
-            ).success?.first
+            if storeProduct.productType == 17 {
+				// If the product type is 17, we need to fetch the shoe size recommendations
+				bodyProfileRecommendedSize = await VirtusizeAPIService.getBodyProfileRecommendedShoeSizeAsync(
+					productTypes: productTypes!,
+					storeProduct: storeProduct,
+					userBodyProfile: userBodyProfile
+            	).success
+			} else {
+				bodyProfileRecommendedSize = await VirtusizeAPIService.getBodyProfileRecommendedItemSizesAsync(
+					productTypes: productTypes!,
+					storeProduct: storeProduct,
+					userBodyProfile: userBodyProfile
+            	).success?.first
+			}
 		}
 
 		var userProducts = self.userProducts ?? []

--- a/Virtusize/Tests/APIRequestTests.swift
+++ b/Virtusize/Tests/APIRequestTests.swift
@@ -167,10 +167,12 @@ class APIRequestTests: XCTestCase {
         XCTAssertEqual(apiRequest?.httpMethod, APIMethod.post.rawValue)
         XCTAssertEqual(apiRequest?.allHTTPHeaderFields?["x-vs-bid"] ?? "", UserDefaultsHelper.current.identifier)
         XCTAssertNotNil(apiRequest?.httpBody)
-        let actualParams = try? JSONDecoder().decode(VirtusizeGetSizeParams.self, from: apiRequest!.httpBody!)
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+        let actualParams = try? decoder.decode(VirtusizeGetSizeParams.self, from: apiRequest!.httpBody!)
         XCTAssertNotNil(actualParams)
         XCTAssertEqual(actualParams?.items.first?.additionalInfo.count, 6)
-        XCTAssertEqual(actualParams?.items.first?.additionalInfo["gender"]?.value as? String, "female")
+        XCTAssertEqual(actualParams?.items.first?.additionalInfo["gender"]?.value as? String, "male")
         XCTAssertEqual(
             actualParams?.items.first?.additionalInfo["sizes"]?.value as? [String: [String: Int?]],
             ["37": [

--- a/Virtusize/Tests/VirtusizeAPIServiceTests.swift
+++ b/Virtusize/Tests/VirtusizeAPIServiceTests.swift
@@ -536,7 +536,7 @@ class VirtusizeAPIServiceTests: XCTestCase {
         )
 
         let task = Task {
-            actualRecommendedSizes = await VirtusizeAPIService.getBodyProfileRecommendedSizesAsync(
+            actualRecommendedSizes = await VirtusizeAPIService.getBodyProfileRecommendedItemSizesAsync(
                 productTypes: TestFixtures.getProductTypes(),
                 storeProduct: TestFixtures.getStoreProduct(gender: "female")!,
                 userBodyProfile: TestFixtures.getUserBodyProfile()!
@@ -549,7 +549,7 @@ class VirtusizeAPIServiceTests: XCTestCase {
 		task.cancel()
 
         XCTAssertNotNil(actualRecommendedSizes)
-        XCTAssertEqual(actualRecommendedSizes?.first?.sizeName, "35")
+        XCTAssertEqual(actualRecommendedSizes?.first?.getSizeName, "35")
     }
 
 	func testGetUserBodyRecommendedSize_inseamAsNumber() throws {

--- a/Virtusize/Tests/VirtusizeGetSizeParamsTests.swift
+++ b/Virtusize/Tests/VirtusizeGetSizeParamsTests.swift
@@ -38,6 +38,7 @@ class VirtusizeGetSizeParamsTests: XCTestCase {
         let expectedGetSizeParamsData = Data(
             """
             {
+                "appOrigin": 2,
                 "userGender": "female",
                 "userHeight": 1630,
                 "userWeight": 50,
@@ -100,15 +101,15 @@ class VirtusizeGetSizeParamsTests: XCTestCase {
                         "value": 300,
                         "predicted": true
                     },
-                    "bustWidth": {
+                    "bust_width": {
                         "value": 245,
                         "predicted": true
                     },
-                    "sleeveLength": {
+                    "sleeve_length": {
                         "value": 520,
                         "predicted": true
                     },
-                    "shoulderWidth": {
+                    "shoulder_width": {
                         "value": 340,
                         "predicted": true
                     },
@@ -116,7 +117,7 @@ class VirtusizeGetSizeParamsTests: XCTestCase {
                         "value": 630,
                         "predicted": true
                     },
-                    "waistHeight": {
+                    "waist_height": {
                         "value": 920,
                         "predicted": true
                     },
@@ -132,15 +133,15 @@ class VirtusizeGetSizeParamsTests: XCTestCase {
                         "value": 755,
                         "predicted": true
                     },
-                    "shoulderHeight": {
+                    "shoulder_height": {
                         "value": 1240,
                         "predicted": true
                     },
-                    "waistWidth": {
+                    "waist_width": {
                         "value": 225,
                         "predicted": true
                     },
-                    "hipHeight": {
+                    "hip_height": {
                         "value": 750,
                         "predicted": true
                     },
@@ -156,19 +157,19 @@ class VirtusizeGetSizeParamsTests: XCTestCase {
                         "value": 215,
                         "predicted": true
                     },
-                    "headHeight": {
+                    "head_height": {
                         "value": 215,
                         "predicted": true
                     },
-                    "kneeHeight": {
+                    "knee_height": {
                         "value": 395,
                         "predicted": true
                     },
-                    "armpitHeight": {
+                    "armpit_height": {
                         "value": 1130,
                         "predicted": true
                     },
-                    "hipWidth": {
+                    "hip_width": {
                         "value": 300,
                         "predicted": true
                     },
@@ -229,6 +230,7 @@ class VirtusizeGetSizeParamsTests: XCTestCase {
         let expectedGetSizeParamsData = Data(
             """
             {
+                "appOrigin": 2,
                 "bodyData": {},
                 "items": [
                     {
@@ -237,7 +239,7 @@ class VirtusizeGetSizeParamsTests: XCTestCase {
                             "fit": "regular",
                             "sizes": {},
                             "modelInfo": null,
-                            "gender": null,
+                            "gender": "null",
                             "style": "fashionable"
                         },
                         "itemSizesOrig": {},


### PR DESCRIPTION
## 🔗 Related Links

- [x] [ClickUp](https://app.clickup.com/t/3702259/NSDK-294)

## ⬅️ As Is

Explain the current situation of the code

IOS SDK uses outdated size recommendation API requests

## ➡️ To Be

- [x] IOS SDK size recommendation API requests are aligned with web implementation

## ☑️ Checklist

- [x] Useless comments and/or `Log.d` etc are **removed**
- [x] Unit test are **covered**
- [ ] Code has been **deployed and tested** on STG
- [ ] ClickUp ticket status has been **updated** to `production`
- [x] Update CHANGELOG.md with the new changes
