### PR TITLE
Fix import Foundation error

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,9 @@ Use list notation, and following prefixes:
 - Bugfix - when fixing any major bug
 - Docs - for any improvement to documentation
 
+### Future release
+- Fix: Compilation error when packages added via Swift Package Manager, due to missing explicit `import Foundation`
+
 ### 2.12.4
 - Fix: Align mobile SDK size recommendation API requests with web implementation
 

--- a/Virtusize/Sources/Internal/Models/VirtusizeGetSizeParams.swift
+++ b/Virtusize/Sources/Internal/Models/VirtusizeGetSizeParams.swift
@@ -22,6 +22,8 @@
 //  THE SOFTWARE.
 //
 
+import Foundation
+
 // swiftlint:disable:next line_length
 /// The structure that wraps the parameters for the API request to get the recommended size based on a user's body profile
 internal struct VirtusizeGetSizeParams: Codable {

--- a/Virtusize/Sources/Internal/Models/VirtusizeGetSizeParamsShoe.swift
+++ b/Virtusize/Sources/Internal/Models/VirtusizeGetSizeParamsShoe.swift
@@ -22,6 +22,8 @@
 //  THE SOFTWARE.
 //
 
+import Foundation
+
 // swiftlint:disable:next line_length
 /// The structure that wraps the parameters for the API request to get the recommended size based on a user's body profile
 internal struct VirtusizeGetSizeParamsShoe: Codable {


### PR DESCRIPTION
## ⬅️ As Is

Explain the current situation of the code

There is a compilation error when packages added via Swift Package Manager, due to missing explicit `import Foundation`

## ➡️ To Be

- [x] There is no compilation error when packages added via Swift Package Manager, due to missing explicit `import Foundation`

## ☑️ Checklist

- [x] Useless comments and/or `print` etc are **removed**
- [x] Unit test are **covered**
- [ ] Code has been **deployed and tested** on STG
- [ ] ClickUp ticket status has been **updated** to `production`
- [x] Update CHANGELOG.md with the new changes
