### PR TITLE
Handle user-clicked-language event

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,10 @@ Use list notation, and following prefixes:
 - Bugfix - when fixing any major bug
 - Docs - for any improvement to documentation
 
+### Future release
+- Feature: Add handling of language change on web in Virtusize widgets
+- Fix: Display error state of VirtusizeInPageStandard widget
+
 ### 2.12.5
 - Fix: Compilation error when packages added via Swift Package Manager, due to missing explicit `import Foundation`
 

--- a/Virtusize/Sources/Internal/DefaultEventHandler.swift
+++ b/Virtusize/Sources/Internal/DefaultEventHandler.swift
@@ -65,4 +65,8 @@ internal class DefaultEventHandler: VirtusizeEventHandler, VirtusizeViewEventPro
 	public func userClosedWidget() {
 		handleUserClosedWidget()
 	}
+
+	public func userClickedLanguage(language: VirtusizeLanguage) {
+		handleUserClickedLanguage(language: language)
+	}
 }

--- a/Virtusize/Sources/Models/VirtusizeEventName.swift
+++ b/Virtusize/Sources/Models/VirtusizeEventName.swift
@@ -37,4 +37,5 @@ public enum VirtusizeEventName: String {
 	case userLoggedIn = "user-logged-in"
 	case userLoggedOut = "user-logged-out"
 	case userDeletedData = "user-deleted-data"
+	case userClickedLanguage = "user-clicked-language"
 }

--- a/Virtusize/Sources/Models/VirtusizeLanguage.swift
+++ b/Virtusize/Sources/Models/VirtusizeLanguage.swift
@@ -23,7 +23,7 @@
 //
 
 /// This enum contains all the possible display languages of the Virtusize web app
-public enum VirtusizeLanguage: String, CaseIterable {
+public enum VirtusizeLanguage: String, CaseIterable, Sendable {
 	case ENGLISH = "en"
 	case JAPANESE = "ja"
 	case KOREAN = "ko"

--- a/Virtusize/Sources/UI/VirtusizeButton.swift
+++ b/Virtusize/Sources/UI/VirtusizeButton.swift
@@ -80,6 +80,13 @@ public class VirtusizeButton: UIButton, VirtusizeView, VirtusizeViewEventProtoco
 			name: .storeProduct,
 			object: Virtusize.self
 		)
+        
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(didReceiveSetLanguageEvent(_:)),
+            name: .setLanguage,
+            object: Virtusize.self
+        )
 	}
 
 	@objc func didReceiveProductCheckData(_ notification: Notification) {
@@ -94,6 +101,15 @@ public class VirtusizeButton: UIButton, VirtusizeView, VirtusizeViewEventProtoco
 			self.serverProduct = storeProduct
 		}
 	}
+    
+    @objc func didReceiveSetLanguageEvent(_ notification: Notification) {
+        guard let notificationData = notification.userInfo as? [String: Any],
+              let language = notificationData[NotificationKey.setLanguage] as? VirtusizeLanguage else {
+            return
+        }
+        
+        setTitle(Localization.shared.localize("check_size", language: language), for: .normal)
+    }
 
 	/// Set up the style of `VirtusizeButton`
 	private func setStyle() {
@@ -175,4 +191,8 @@ extension VirtusizeButton: VirtusizeEventHandler {
     public func userClosedWidget() {
         handleUserClosedWidget()
     }
+
+	public func userClickedLanguage(language: VirtusizeLanguage) {
+		handleUserClickedLanguage(language: language)
+	}
 }

--- a/Virtusize/Sources/UI/VirtusizeInPageStandard.swift
+++ b/Virtusize/Sources/UI/VirtusizeInPageStandard.swift
@@ -116,6 +116,7 @@ public class VirtusizeInPageStandard: VirtusizeInPageView { // swiftlint:disable
 	}
 
 	internal override func didReceiveSizeRecommendationData(_ notification: Notification) {
+        super.didReceiveSizeRecommendationData(notification)
 		shouldUpdateInPageRecommendation(notification) { sizeRecData in
 			serverProduct = sizeRecData.serverProduct
 
@@ -136,6 +137,7 @@ public class VirtusizeInPageStandard: VirtusizeInPageView { // swiftlint:disable
 	}
 
 	internal override func didReceiveInPageError(_ notification: Notification) {
+        super.didReceiveInPageError(notification)
 		showLoadingGif(false)
 		shouldShowInPageErrorScreen(notification) {
 			inPageStandardView.layer.shadowOpacity = 0
@@ -153,6 +155,30 @@ public class VirtusizeInPageStandard: VirtusizeInPageView { // swiftlint:disable
 			errorText.textAlignment = .center
 		}
 	}
+    
+    internal override func didReceiveSetLanguageEvent(_ notification: Notification) {
+        guard let notificationData = notification.userInfo as? [String: Any],
+              let language = notificationData[NotificationKey.setLanguage] as? VirtusizeLanguage else {
+            return
+        }
+        
+        checkSizeButton.setTitle(Localization.shared.localize("check_size", language: language), for: .normal)
+        privacyPolicyLink.text = Localization.shared.localize("privacy_policy", language: language)
+        setRecommendationTexts()
+        
+        if isLoading{
+            startLoadingTextAnimation(
+                label: bottomMessageLabel,
+                text: Localization.shared.localize("inpage_loading_text", language: language)
+            )
+        } else if isError{
+            errorText.attributedText = NSAttributedString(
+                string: Localization.shared.localize("inpage_error_long_text", language: language)
+            ).lineSpacing(self.messageLineSpacing)
+        } else {
+            setRecommendationTexts()
+        }
+    }
 
 	private func bind(to viewModel: VirtusizeInPageStandardViewModel) {
 		viewModel.userProductImageObservable.observe(on: self) { [weak self] userProductImage in

--- a/Virtusize/Sources/UI/VirtusizeInPageView.swift
+++ b/Virtusize/Sources/UI/VirtusizeInPageView.swift
@@ -47,7 +47,6 @@ public class VirtusizeInPageView: UIView, VirtusizeView, VirtusizeViewEventProto
 	required init?(coder: NSCoder) {
 		super.init(coder: coder)
 		virtusizeEventHandler = self
-		isLoading = true
 		addSubviews()
 		setup()
 		addNotificationObserver()
@@ -56,7 +55,6 @@ public class VirtusizeInPageView: UIView, VirtusizeView, VirtusizeViewEventProto
 	public override init(frame: CGRect) {
 		super.init(frame: .zero)
 		virtusizeEventHandler = self
-		isLoading = true
 		addSubviews()
 		setup()
 		addNotificationObserver()
@@ -66,7 +64,8 @@ public class VirtusizeInPageView: UIView, VirtusizeView, VirtusizeViewEventProto
 	internal let contentContainerView: UIView = UIView()
 	// Loading GIF image view
 	private let loadingGifImageView: UIImageView = UIImageView()
-	private var isLoading: Bool = false
+    internal var isLoading: Bool = false
+    internal var isError: Bool = false
 
 	private func addSubviews() {
 		// Add loading GIF image view
@@ -96,6 +95,7 @@ public class VirtusizeInPageView: UIView, VirtusizeView, VirtusizeViewEventProto
 
 	internal func showLoadingGif(_ show: Bool) {
 		isHidden = false
+        isLoading = show
 		loadingGifImageView.isHidden = !show
 		contentContainerView.isHidden = show
 	}
@@ -129,13 +129,23 @@ public class VirtusizeInPageView: UIView, VirtusizeView, VirtusizeViewEventProto
 			name: .inPageError,
 			object: Virtusize.self
 		)
+        
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(didReceiveSetLanguageEvent(_:)),
+            name: .setLanguage,
+            object: Virtusize.self
+        )
 	}
-
+    
+    @objc internal func didReceiveSetLanguageEvent(_ notification: Notification) {}
+    
 	@objc internal func didReceiveProductCheckData(_ notification: Notification) {
 		shouldUpdateProductCheckData(notification) { productWithPDCData in
 			self.clientProduct = productWithPDCData
 			showLoadingGif(false)
 			setLoadingScreen(loading: true)
+            isLoading = true
 		}
 	}
 
@@ -146,7 +156,10 @@ public class VirtusizeInPageView: UIView, VirtusizeView, VirtusizeViewEventProto
 	}
 
 	/// A parent function to set up InPage recommendation
-	@objc internal func didReceiveSizeRecommendationData(_ notification: Notification) {}
+	@objc internal func didReceiveSizeRecommendationData(_ notification: Notification) {
+        isLoading = false
+        isError = false
+    }
 
 	internal func shouldUpdateInPageRecommendation(
 		_ notification: Notification,
@@ -173,13 +186,17 @@ public class VirtusizeInPageView: UIView, VirtusizeView, VirtusizeViewEventProto
 	}
 
 	/// A parent function for showing the error screen
-	@objc internal func didReceiveInPageError(_ notification: Notification) {}
+	@objc internal func didReceiveInPageError(_ notification: Notification) {
+        isError = true
+    }
 
 	/// Sets up the styles for the loading screen and the screen after finishing loading
 	///
 	/// - Parameters:
 	///   - loading: Pass true when it's loading, and pass false when finishing loading
-	internal func setLoadingScreen(loading: Bool) {}
+	internal func setLoadingScreen(loading: Bool) {
+        isError = false
+    }
 
 	internal func setup() {}
 
@@ -279,6 +296,10 @@ extension VirtusizeInPageView: VirtusizeEventHandler {
 
     public func userClosedWidget() {
         handleUserClosedWidget()
+    }
+    
+    public func userClickedLanguage(language: VirtusizeLanguage) {
+        handleUserClickedLanguage(language: language)
     }
 
 	internal func setContentViewListener(listener: ((VirtusizeInPageView) -> Void)?) {

--- a/Virtusize/Sources/UI/VirtusizeNotification.swift
+++ b/Virtusize/Sources/UI/VirtusizeNotification.swift
@@ -29,6 +29,7 @@ extension Notification.Name {
 	static let storeProduct = Notification.Name(NotificationKey.storeProduct)
 	static let sizeRecommendationData = Notification.Name(NotificationKey.sizeRecommendationData)
 	static let inPageError = Notification.Name(NotificationKey.inPageError)
+    static let setLanguage = Notification.Name(NotificationKey.setLanguage)
 }
 
 struct NotificationKey {
@@ -36,4 +37,5 @@ struct NotificationKey {
 	static let storeProduct = "storeProduct"
 	static let sizeRecommendationData = "sizeRecommendationData"
 	static let inPageError = "inPageError"
+    static let setLanguage = "setLanguage"
 }

--- a/Virtusize/Sources/UI/VirtusizeViewEventProtocol.swift
+++ b/Virtusize/Sources/UI/VirtusizeViewEventProtocol.swift
@@ -107,4 +107,10 @@ extension VirtusizeViewEventProtocol {
 			await VirtusizeRepository.shared.updateUserSession(forceUpdate: true)
 		}
 	}
+
+	public func handleUserClickedLanguage(language: VirtusizeLanguage) {
+		Task {
+            await Virtusize.setDisplayLanguage(language: language)
+		}
+	}
 }

--- a/Virtusize/Sources/Virtusize.swift
+++ b/Virtusize/Sources/Virtusize.swift
@@ -198,4 +198,18 @@ public class Virtusize {
 	public class func handleUrl(_ url: URL) -> Bool {
 		return VirtusizeAuthorization.shared.handleUrl(url)
 	}
+
+	/// Sets the display language for the Virtusize views
+	///
+	/// - Parameter language: VirtusizeLanguage to be set for the views
+	public class func setDisplayLanguage(language: VirtusizeLanguage) async {
+		await virtusizeRepository.setDisplayLanguage(language: language)
+        DispatchQueue.main.async {
+			NotificationCenter.default.post(
+				name: .setLanguage,
+				object: Virtusize.self,
+				userInfo: [NotificationKey.setLanguage: language]
+			)
+		}
+	}
 }

--- a/Virtusize/Sources/Virtusize.swift
+++ b/Virtusize/Sources/Virtusize.swift
@@ -123,7 +123,8 @@ public class Virtusize {
 			let productWithPDCData = await virtusizeRepository.checkProductValidity(product: product)
 
 			guard let productWithPDCData = productWithPDCData else {
-				return
+                inPageError = (true, product.externalId)
+                return
 			}
 
 			await virtusizeRepository.updateUserSession()
@@ -141,6 +142,7 @@ public class Virtusize {
 			)
 
 			guard let serverProduct = serverProduct else {
+                inPageError = (true, product.externalId)
 				return
 			}
 

--- a/Virtusize/Sources/VirtusizeEventHandler.swift
+++ b/Virtusize/Sources/VirtusizeEventHandler.swift
@@ -35,4 +35,5 @@ public protocol VirtusizeEventHandler {
 	func userUpdatedBodyMeasurements(recommendedSize: String?)
 	func userChangedRecommendationType(changedType: SizeRecommendationType?)
     func userClosedWidget()
+	func userClickedLanguage(language: VirtusizeLanguage)
 }

--- a/Virtusize/Sources/VirtusizeRepository.swift
+++ b/Virtusize/Sources/VirtusizeRepository.swift
@@ -409,4 +409,9 @@ internal class VirtusizeRepository: NSObject { // swiftlint:disable:this type_bo
 
 		return Deserializer.i18n(json: i18nJson)
 	}
+
+	internal func setDisplayLanguage(language: VirtusizeLanguage) async {
+		async let i18nTask = fetchLocalization(language: language)
+		i18nLocalization = await i18nTask
+	}
 } // swiftlint:disable:this file_length


### PR DESCRIPTION
## 🔗 Related Links

- [x] [ClickUp 1](https://app.clickup.com/t/3702259/NSDK-296)
- [x] [ClickUp 2](https://app.clickup.com/t/3702259/NSDK-297)

## ⬅️ As Is

Explain the current situation of the code

- Changing language on web is not reflected in Virtusize widgets
- Error state is not displayed for VirtusizeInPageStandard widget

## ➡️ To Be

- [ ]  Language in Virtusize widgets is changed after selecting language on web
- [ ] Error state is displayed for VirtusizeInPageStandard widget

## ☑️ Checklist

- [x] Useless comments and/or `print` etc are **removed**
- [x] Unit test are **covered**
- [ ] Code has been **deployed and tested** on STG
- [ ] ClickUp ticket status has been **updated** to `production`
- [x] Update CHANGELOG.md with the new changes
