### PR TITLE
Fix sizing errors of VirtusizeInPageStandard inside of SwiftUIVirtusizeInPageStandard

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,9 @@ Use list notation, and following prefixes:
 - Bugfix - when fixing any major bug
 - Docs - for any improvement to documentation
 
+### Next release
+- Fix: Sizing of VirtusizeInPageStandard widget in error state
+
 ### 2.12.6
 - Feature: Add event listener to handle language change on web in Virtusize widgets
 - Fix: Display error state of VirtusizeInPageStandard widget

--- a/Virtusize/Sources/UI/VirtusizeInPageStandard.swift
+++ b/Virtusize/Sources/UI/VirtusizeInPageStandard.swift
@@ -133,6 +133,10 @@ public class VirtusizeInPageStandard: VirtusizeInPageView { // swiftlint:disable
 				clientProductImageURL: clientProduct?.imageURL,
 				storeProduct: sizeRecData.serverProduct
 			)
+			invalidateIntrinsicContentSize()
+			DispatchQueue.main.async {
+				self.contentViewListener?(self)
+			}
 		}
 	}
 
@@ -153,6 +157,10 @@ public class VirtusizeInPageStandard: VirtusizeInPageView { // swiftlint:disable
 				string: Localization.shared.localize("inpage_error_long_text")
 			).lineSpacing(self.messageLineSpacing)
 			errorText.textAlignment = .center
+			invalidateIntrinsicContentSize()
+			DispatchQueue.main.async {
+				self.contentViewListener?(self)
+			}
 		}
 	}
     
@@ -454,11 +462,11 @@ public class VirtusizeInPageStandard: VirtusizeInPageView { // swiftlint:disable
 
 		errorImageView.image = VirtusizeAssets.errorHanger
 		errorImageView.contentMode = .scaleAspectFit
-		errorImageView.isHidden = true
+		errorImageView.isHidden = !isError
 
 		errorText.numberOfLines = 0
 		errorText.textColor = .vsGray700Color
-		errorText.isHidden = true
+		errorText.isHidden = !isError
 
 		let displayLanguage = Virtusize.params?.language
 		let messageTextSize = messageFontSize ?? 12
@@ -497,6 +505,12 @@ public class VirtusizeInPageStandard: VirtusizeInPageView { // swiftlint:disable
 		   let url = URL(string: Localization.shared.localize("privacy_policy_link")) {
 			sharedApplication.safeOpenURL(url)
 		}
+	}
+
+	public override var intrinsicContentSize: CGSize {
+	    layoutIfNeeded()
+	    var contentHeight = contentContainerView.systemLayoutSizeFitting(UIView.layoutFittingCompressedSize).height
+	    return CGSize(width: UIView.noIntrinsicMetric, height: contentHeight)
 	}
 
 	private func adjustProductImageViewPosition(userProductImageSize: CGFloat, productImageViewOffset: CGFloat) {


### PR DESCRIPTION
…zeInPageStandard

## 🔗 Related Links

- [x] [ClickUp](https://app.clickup.com/t/3702259/NSDK-299)

## ⬅️ As Is

Explain the current situation of the code

- Because of the sizing problems, VirtusizeInPageStandard widget is overlayed by other views when in error state.

## ➡️ To Be

- [x] VirtusizeInPageStandard widget is given right size and is not overlayed by other views when in error state.

## ☑️ Checklist

- [x] Useless comments and/or `print` etc are **removed**
- [x] Unit test are **covered**
- [ ] Code has been **deployed and tested** on STG
- [ ] ClickUp ticket status has been **updated** to `production`
- [x] Update CHANGELOG.md with the new changes
