### PR TITLE
NSDK-423 - app crash on **externalProductId** is nil

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,10 @@ Use list notation, and following prefixes:
 - Bugfix - when fixing any major bug
 - Docs - for any improvement to documentation
 
+### Changes
+- Fix: crash on externalProductId nil
+- Fix: Sentry logger for Flutter 
+
 ### 2.12.29
 - Hotfix: Swift Package Manager dependencies
 

--- a/Package.swift
+++ b/Package.swift
@@ -20,7 +20,7 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(url: "https://github.com/getsentry/sentry-cocoa.git", exact: "9.6.0")
+        .package(url: "https://github.com/getsentry/sentry-cocoa.git", exact: "9.13.0")
     ],
     targets: [
         .target(

--- a/Package.swift
+++ b/Package.swift
@@ -20,7 +20,7 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(url: "https://github.com/getsentry/sentry-cocoa.git", exact: "9.13.0")
+        .package(url: "https://github.com/getsentry/sentry-cocoa.git", from: "9.13.0")
     ],
     targets: [
         .target(

--- a/Virtusize.podspec
+++ b/Virtusize.podspec
@@ -18,7 +18,7 @@ Pod::Spec.new do |s|
   s.resource_bundle = { 'Virtusize' => ["Virtusize/Sources/Resources/**/*.lproj", "Virtusize/Sources/Resources/PrivacyInfo.xcprivacy"] }
 
   s.pod_target_xcconfig = { 'BUILD_LIBRARY_FOR_DISTRIBUTION' => 'YES' }
-  s.dependency 'Sentry', '9.6.0'
+  s.dependency 'Sentry', '9.13.0'
   s.subspec 'VirtusizeCore' do |ss|
     ss.dependency 'VirtusizeCore', "#{s.version}"
   end

--- a/Virtusize.xcodeproj/project.pbxproj
+++ b/Virtusize.xcodeproj/project.pbxproj
@@ -1214,7 +1214,7 @@
 			repositoryURL = "https://github.com/getsentry/sentry-cocoa";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 9.4.1;
+				minimumVersion = 9.13.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/Virtusize.xcodeproj/project.pbxproj
+++ b/Virtusize.xcodeproj/project.pbxproj
@@ -1216,6 +1216,8 @@
 				kind = upToNextMajorVersion;
 				minimumVersion = 9.13.0;
 			};
+			traits = (
+			);
 		};
 /* End XCRemoteSwiftPackageReference section */
 

--- a/Virtusize/Sources/Internal/VirtusizeSentryTracker.swift
+++ b/Virtusize/Sources/Internal/VirtusizeSentryTracker.swift
@@ -44,21 +44,16 @@ internal final class VirtusizeSentryTracker {
     }
 
     private func initSentry() {
-        let moduleBundle = Bundle(for: Virtusize.self)
-
-        if let dsn = moduleBundle.object(forInfoDictionaryKey: "SentryDSN") as? String {
-            SentrySDK.start { options in
-                options.dsn = dsn
-                //options.tracesSampleRate = moduleBundle.object(forInfoDictionaryKey: "SentryTracesSampleRate") as? NSNumber ?? 1.0
-                options.debug = false
-                options.environment = Virtusize.environment.rawValue
-                options.enableLogs = true
-                options.experimental.enableMetrics = true
-            }
-            SentrySDK.configureScope { scope in
-                scope.setTag(value: VirtusizeConfiguration.SDKVersion, key: "sdk_version")
-                scope.setTag(value: "ios", key: "sdk_platform")
-            }
+        SentrySDK.start { options in
+            options.dsn = "https://f2ae6aac72a9ec47631fdbc4cd8589e6@o903.ingest.us.sentry.io/4510877679353856"
+            options.debug = false
+            options.environment = Virtusize.environment.rawValue
+            options.enableLogs = true
+            options.experimental.enableMetrics = true
+        }
+        SentrySDK.configureScope { scope in
+            scope.setTag(value: VirtusizeConfiguration.SDKVersion, key: "sdk_version")
+            scope.setTag(value: "ios", key: "sdk_platform")
         }
     }
 

--- a/Virtusize/Sources/Internal/VirtusizeSentryTracker.swift
+++ b/Virtusize/Sources/Internal/VirtusizeSentryTracker.swift
@@ -49,7 +49,7 @@ internal final class VirtusizeSentryTracker {
             options.debug = false
             options.environment = Virtusize.environment.rawValue
             options.enableLogs = true
-            options.experimental.enableMetrics = true
+            options.enableMetrics = true
         }
         SentrySDK.configureScope { scope in
             scope.setTag(value: VirtusizeConfiguration.SDKVersion, key: "sdk_version")

--- a/Virtusize/Sources/Models/VirtusizeParams.swift
+++ b/Virtusize/Sources/Models/VirtusizeParams.swift
@@ -74,17 +74,17 @@ public class VirtusizeParams {
     /// - Parameters:
     ///   - externalProductId:The external product ID provided by the client.
     ///   - userSessionResponse: The user session API response
-    /// - Returns: A string value of the script in JavaScript
+    /// - Returns: A string value of the script in JavaScript, or nil if required params are missing
     func getVsParamsFromSDKScript(
         externalProductId: String?,
         userSessionResponse: String = ""
-    ) -> String {
+    ) -> String? {
         var paramsScript = "vsParamsFromSDK("
         guard let apiKey = Virtusize.APIKey else {
-            fatalError("Please set Virtusize.APIKey")
+            return nil
         }
         guard let externalProductId = externalProductId else {
-            fatalError("The external product ID is invalid")
+            return nil
         }
         paramsScript += "{\(ParamKey.API): '\(apiKey)', "
         paramsScript += "\(ParamKey.browserID): '\(UserDefaultsHelper.current.identifier)', "

--- a/Virtusize/Sources/Virtusize.swift
+++ b/Virtusize/Sources/Virtusize.swift
@@ -116,10 +116,26 @@ public class Virtusize {
 
 	internal typealias InPageError = (hasError: Bool, externalProductId: String)
 
+	/// Lock for thread-safe access to inPageError
+	private static let inPageErrorLock = NSLock()
+
+	/// The backing storage for inPageError
+	private static var _inPageError: InPageError?
+
 	/// The property to be set to show the InPage error screen with the associated external product ID
 	internal static var inPageError: InPageError? {
-		didSet {
-			if let inPageError = inPageError {
+		get {
+			inPageErrorLock.lock()
+			defer { inPageErrorLock.unlock() }
+			return _inPageError
+		}
+		set {
+			inPageErrorLock.lock()
+			_inPageError = newValue
+			let value = _inPageError
+			inPageErrorLock.unlock()
+
+			if let inPageError = value {
 				DispatchQueue.main.async {
 					NotificationCenter.default.post(
 						name: .inPageError,


### PR DESCRIPTION
- Fix: crash on externalProductId nil
- Fix: Sentry logger for Flutter 

## 🔗 Related Links

- [ ] [ClickUp](https://app.clickup.com/t/3702259/NSDK-423)

## ⬅️ As Is

Application crash on open webview in **externalProductId** is nil condition 

## ➡️ To Be

Added a condition check and break excution on **externalProductId** is nil

## ☑️ Checklist

- [ ] Useless comments and/or `print` etc are **removed**
- [ ] Unit test are **covered**
- [ ] Code has been **deployed and tested** on STG
- [ ] ClickUp ticket status has been **updated** to `production`
- [ ] Update CHANGELOG.md with the new changes
